### PR TITLE
Add in edit distances during inference to known segments

### DIFF
--- a/main.py
+++ b/main.py
@@ -270,6 +270,10 @@ def annotate_reads(
         None,
         help="Path to the seq_orders.tsv file. If not provided, uses the default from utils."
     ),
+    whitelist_base_dir: str = typer.Option(
+        None,
+        help="Directory containing whitelist files (cbc.txt, udi_i5.txt, udi_i7.txt) for edit distance calculations"
+    ),
     chunk_size: int = typer.Option(
         100000, help=(
         "Base chunk size, dynamically adjusts based on read length"
@@ -337,11 +341,12 @@ def annotate_reads(
         RuntimeError: Propagated exceptions from worker processes.
     """
     from wrappers.annotate_reads_wrap import annotate_reads_wrap
-    annotate_reads_wrap(output_dir, whitelist_file, output_fmt, 
+    annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                         model_name, model_type, seq_order_file,
                         chunk_size, gpu_mem, target_tokens,
                         vram_headroom, min_batch_size, max_batch_size,
-                        bc_lv_threshold, threads, max_queue_size)
+                        bc_lv_threshold, threads, max_queue_size,
+                        whitelist_base_dir)
 
 # ======================================
 # align inserts to the reference genome

--- a/main.py
+++ b/main.py
@@ -293,10 +293,6 @@ def annotate_reads(
         None,
         help="Path to the seq_orders.tsv file. If not provided, uses the default from utils."
     ),
-    whitelist_base_dir: str = typer.Option(
-        None,
-        help="Directory containing whitelist files (cbc.txt, udi_i5.txt, udi_i7.txt) for edit distance calculations"
-    ),
     whitelists: str = typer.Option(
         None,
         help="Comma-separated whitelist overrides in the form <segment>:<file>. Only segments present in seq_orders are loaded."
@@ -357,7 +353,6 @@ def annotate_reads(
         output_fmt: "fasta" or "fastq" for demultiplexed outputs.
         model_name: Base model label (without `_w_CRF`).
         model_type: "REG", "CRF", or "HYB" (REG pass then CRF on invalid).
-        whitelist_base_dir: Directory of whitelist files used for edit-distance calculations.
         whitelists: Comma-separated segment:path overrides for edit-distance whitelists (only segments in seq_orders are used).
         chunk_size: Row group size for final Parquet conversions.
         gpu_mem: Optional GPU memory budget string (e.g., "12" or "8,16").
@@ -390,7 +385,7 @@ def annotate_reads(
                         chunk_size, gpu_mem, target_tokens,
                         vram_headroom, min_batch_size, max_batch_size,
                         bc_lv_threshold, threads, max_queue_size,
-                        whitelist_base_dir, include_edit_distances,
+                        include_edit_distances,
                         include_sequences, whitelist_paths)
 
 # ======================================

--- a/scripts/export_annotations_with_edit_distances.py
+++ b/scripts/export_annotations_with_edit_distances.py
@@ -584,8 +584,7 @@ def process_full_length_reads_in_chunks_and_save(
                 # Merge on ReadName to preserve edit distance, segment position, and essential columns
                 preserved_df = valid_reads_df[['ReadName'] + cols_to_preserve]
                 corrected_df = corrected_df.merge(preserved_df, on='ReadName', how='left')
-                logger.info(f"Preserved {len(cols_to_preserve)} columns in valid reads output "
-                           f"(filtered to exclude columns already in bc_n_demultiplex output)")
+                logger.info(f"Preserved {len(cols_to_preserve)} columns in valid reads output")
             else:
                 logger.info("No additional columns to preserve - all needed columns already in bc_n_demultiplex output")
 

--- a/scripts/export_annotations_with_edit_distances.py
+++ b/scripts/export_annotations_with_edit_distances.py
@@ -1,0 +1,532 @@
+import os
+import re
+import gc
+import csv
+import logging
+import numpy as np
+import pandas as pd
+import polars as pl
+import seaborn as sns
+import tensorflow as tf
+from filelock import FileLock
+import matplotlib.pyplot as plt
+from rapidfuzz.distance import Levenshtein
+
+from matplotlib.backends.backend_pdf import PdfPages
+from scripts.correct_barcodes import bc_n_demultiplex
+from scripts.extract_annotated_seqs import extract_annotated_full_length_seqs
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Edit Distance Helper Functions
+# TODO: reorganize into an Annotations class for better portability
+# This exists in parallel with the export_annotations.py for testing
+# It will be integrated into the existing export_annotations.py once
+# it's confirmed to work as intended.
+
+def reverse_complement(seq):
+    """
+    Reverse complement a DNA sequence.
+    Re-defined here, but also exists in simulate_training_data.py
+    and also in correct_barcodes.py using a numba approach that is
+    jit compiled (faster)
+    """
+    complement = {'A': 'T', 'T': 'A', 'G': 'C', 'C': 'G', 'N': 'N'}
+    return ''.join([complement.get(base, 'N') for base in seq[::-1]])
+
+
+def load_whitelist_sequences(whitelist_path):
+    """
+    Load sequences from whitelist file (tab-separated ID\tSequence).
+    These are typically the CBC\ti5\ti7 whitelist/samplesheet
+    """
+    sequences = []
+    if os.path.exists(whitelist_path):
+        with open(whitelist_path, 'r') as f:
+            for line in f:
+                parts = line.strip().split('\t')
+                if len(parts) >= 2:
+                    sequences.append(parts[1])  # Get sequence column
+    return sequences
+
+
+def calculate_min_edit_distance(detected_seq, reference_seqs, check_revcomp=True):
+    """
+    Calculate minimum edit distance between detected sequence and reference list.
+
+    Args:
+        detected_seq: Detected sequence from read
+        reference_seqs: List of reference sequences or single reference sequence
+        check_revcomp: If True, also check reverse complement
+
+    Returns:
+        Tuple of (min_distance, match_orientation)
+          - min_distance: Minimum Levenshtein distance found
+          - match_orientation: 'fwd', 'rev', or None
+    """
+    if not detected_seq or not reference_seqs:
+        return (None, None)
+
+    # Handle single reference sequence
+    if isinstance(reference_seqs, str):
+        reference_seqs = [reference_seqs]
+
+    min_dist = float('inf')
+    best_orientation = None
+
+    # Check forward orientation
+    for ref_seq in reference_seqs:
+        dist = Levenshtein.distance(detected_seq, ref_seq)
+        if dist < min_dist:
+            min_dist = dist
+            best_orientation = 'fwd'
+
+    # Check reverse complement if requested
+    if check_revcomp:
+        detected_rc = reverse_complement(detected_seq)
+        for ref_seq in reference_seqs:
+            dist = Levenshtein.distance(detected_rc, ref_seq)
+            if dist < min_dist:
+                min_dist = dist
+                best_orientation = 'rev'
+
+    return (min_dist if min_dist != float('inf') else None, best_orientation)
+
+
+def load_file_whitelists(whitelist_base_dir=None, cbc_file=None, i5_file=None, i7_file=None):
+    """
+    Load whitelist sequences from separate files as fallback when not in sample sheet.
+
+    Priority:
+    1. If whitelist_base_dir provided, load from standard filenames (cbc.txt, udi_i5.txt, udi_i7.txt)
+    2. If individual files provided (cbc_file, i5_file, i7_file), load from those paths
+
+    Args:
+        whitelist_base_dir: Base directory containing cbc.txt, udi_i5.txt, udi_i7.txt
+        cbc_file: Direct path to CBC whitelist file (fallback)
+        i5_file: Direct path to i5 whitelist file (fallback)
+        i7_file: Direct path to i7 whitelist file (fallback)
+
+    Returns:
+        Dict mapping segment names ('CBC', 'i5', 'i7') to lists of sequences
+    """
+    whitelists = {}
+
+    # Define file mappings
+    if whitelist_base_dir:
+        whitelist_files = {
+            'CBC': os.path.join(whitelist_base_dir, 'cbc.txt'),
+            'i7': os.path.join(whitelist_base_dir, 'udi_i7.txt'),
+            'i5': os.path.join(whitelist_base_dir, 'udi_i5.txt'),
+        }
+    else:
+        # Fallback to individual files
+        whitelist_files = {
+            'CBC': cbc_file,
+            'i7': i7_file,
+            'i5': i5_file,
+        }
+
+    # Load each whitelist
+    for segment, filepath in whitelist_files.items():
+        if filepath and os.path.exists(filepath):
+            whitelists[segment] = load_whitelist_sequences(filepath)
+            if whitelists[segment]:
+                logger.info(f"Loaded {len(whitelists[segment])} sequences for {segment} from {filepath}")
+            else:
+                logger.warning(f"No sequences loaded for {segment} from {filepath}")
+        else:
+            whitelists[segment] = []
+            if filepath:
+                logger.warning(f"Whitelist file not found for {segment}: {filepath}")
+
+    return whitelists
+
+
+def parse_seq_orders_for_known_sequences(seq_orders_path, model_name):
+    """
+    Parse seq_orders.tsv to get known sequences for a specific model.
+
+    Returns:
+        Dict mapping segment labels to their known sequences
+    """
+    known_seqs = {}
+
+    if not os.path.exists(seq_orders_path):
+        logger.warning(f"seq_orders file not found: {seq_orders_path}")
+        return known_seqs
+
+    with open(seq_orders_path, 'r') as f:
+        for line in f:
+            parts = line.strip().split('\t')
+            if len(parts) >= 3 and parts[0] == model_name:
+                # Parse segment order
+                seg_order = parts[1].strip('"').split(',')
+                # Parse sequences
+                seqs = parts[2].strip('"').split(',')
+
+                for label, seq in zip(seg_order, seqs):
+                    # Skip variable length segments (patterns with N)
+                    # But include them for reference
+                    if seq not in ['NN', 'A', 'T']:
+                        known_seqs[label] = seq
+                        # Log fixed sequences only (no N's)
+                        if 'N' not in seq:
+                            logger.info(f"Loaded known sequence for {label}: {seq[:20]}{'...' if len(seq) > 20 else ''}")
+
+                break
+
+    return known_seqs
+
+
+# Cache for loaded whitelists and sequences
+_CACHED_WHITELISTS = None
+_CACHED_KNOWN_SEQUENCES = None
+
+
+def get_or_load_whitelists_and_sequences(seq_orders_path=None, model_name=None, whitelist_base_dir=None):
+    """
+    Get or load whitelists and known sequences (cached).
+
+    Args:
+        seq_orders_path: Path to seq_orders.tsv file
+        model_name: Model name to look up in seq_orders.tsv
+        whitelist_base_dir: Base directory for whitelist files (optional)
+
+    Returns:
+        Tuple of (whitelists_dict, known_sequences_dict)
+    """
+    global _CACHED_WHITELISTS, _CACHED_KNOWN_SEQUENCES
+
+    # Load whitelists if not cached
+    if _CACHED_WHITELISTS is None:
+        _CACHED_WHITELISTS = load_file_whitelists(whitelist_base_dir=whitelist_base_dir)
+
+    # Load known sequences if not cached and parameters provided
+    if _CACHED_KNOWN_SEQUENCES is None and seq_orders_path and model_name:
+        _CACHED_KNOWN_SEQUENCES = parse_seq_orders_for_known_sequences(seq_orders_path, model_name)
+
+    return _CACHED_WHITELISTS, _CACHED_KNOWN_SEQUENCES or {}
+
+# Checkpointing Functions
+
+def save_checkpoint(checkpoint_file, bin_name, chunk):
+    with open(checkpoint_file, "w") as f:
+        f.write(f"{bin_name},{chunk}")
+
+
+def load_checkpoint(checkpoint_file, start_bin):
+    if os.path.exists(checkpoint_file):
+        with open(checkpoint_file, "r") as f:
+            bin_name, chunk = f.readline().strip().split(",")
+        return bin_name, int(chunk)
+    return start_bin, 1
+
+
+
+# Main Processing Function with Edit Distances
+
+def process_full_length_reads_in_chunks_and_save(reads, original_read_names,
+                                                 strand, output_fmt,
+                                                 base_qualities,
+                                                 model_type, pass_num,
+                                                 model_path_w_CRF,
+                                                 predictions, bin_name, chunk_idx,
+                                                 label_binarizer,
+                                                 cumulative_barcodes_stats,
+                                                 actual_lengths, seq_order,
+                                                 add_header, output_dir,
+                                                 invalid_output_file,
+                                                 invalid_file_lock,
+                                                 valid_output_file,
+                                                 valid_file_lock, barcodes,
+                                                 whitelist_df, whitelist_dict,
+                                                 demuxed_fasta,
+                                                 demuxed_fasta_lock,
+                                                 ambiguous_fasta,
+                                                 ambiguous_fasta_lock,
+                                                 threshold, n_jobs,
+                                                 seq_orders_path=None,
+                                                 model_name=None,
+                                                 whitelist_base_dir=None):
+
+    reads_in_chunk = len(reads)
+    logging.info(f"Post-processing {bin_name} chunk - {chunk_idx}: number of reads = {reads_in_chunk}")
+
+    n_jobs_extract = min(16, reads_in_chunk)
+    chunk_contiguous_annotated_sequences = extract_annotated_full_length_seqs(
+        reads, predictions, model_path_w_CRF,
+        actual_lengths, label_binarizer, seq_order,
+        barcodes, n_jobs_extract
+    )
+
+    # Load whitelists and known sequences for edit distance calculation
+    segment_whitelists, known_sequences = get_or_load_whitelists_and_sequences(
+        seq_orders_path, model_name, whitelist_base_dir
+    )
+
+    # Build edit distance columns for barcode segments (with whitelist matching)
+    def get_barcode_edit_dist_cols(annotated_read):
+        """Get edit distance columns for barcode segments."""
+        cols = {}
+        for label in ['CBC', 'i7', 'i5']:
+            if label in barcodes and label in annotated_read:
+                detected_seq = (annotated_read[label]['Sequences'][0]
+                               if annotated_read[label].get('Sequences') else "")
+                min_dist, orientation = calculate_min_edit_distance(
+                    detected_seq,
+                    segment_whitelists.get(label, []),
+                    check_revcomp=True
+                )
+                cols[f'{label}_edit_distance'] = min_dist
+                cols[f'{label}_match_orientation'] = orientation
+        return cols
+
+    # Build edit distance columns for fixed sequences
+    def get_fixed_seq_edit_dist_cols(annotated_read):
+        """Get edit distance columns for fixed reference sequences."""
+        cols = {}
+        for label, ref_seq in known_sequences.items():
+            # Skip variable-length segments (those with N patterns)
+            if 'N' in ref_seq or label in barcodes:
+                continue
+
+            if label in annotated_read:
+                detected_seq = (annotated_read[label]['Sequences'][0]
+                               if annotated_read[label].get('Sequences') else "")
+                min_dist, orientation = calculate_min_edit_distance(
+                    detected_seq,
+                    ref_seq,
+                    check_revcomp=True
+                )
+                cols[f'{label}_edit_distance'] = min_dist
+                cols[f'{label}_match_orientation'] = orientation
+        return cols
+
+    # DataFrame construction with edit distances
+    chunk_df = pd.DataFrame.from_records(
+        (
+            {
+                'ReadName': original_read_names[i],
+                'read_length': annotated_read['read_length'],
+                'read': annotated_read['read'],
+
+                # Existing columns: Start/End positions
+                **{
+                    f'{label}_Starts': ', '.join(map(str, annotations['Starts']))
+                    for label, annotations in annotated_read.items()
+                    if label not in {"architecture", "reason"} and 'Starts' in annotations
+                },
+                **{
+                    f'{label}_Ends': ', '.join(map(str, annotations['Ends']))
+                    for label, annotations in annotated_read.items()
+                    if label not in {"architecture", "reason"} and 'Ends' in annotations
+                },
+
+                # Existing barcode sequences
+                **{
+                    f'{label}_Sequences': ', '.join(map(str, annotated_read[label]['Sequences']))
+                    for label in barcodes
+                    if label in annotated_read and 'Sequences' in annotated_read[label]
+                },
+
+                # Edit distances for barcode segments (against whitelists)
+                **get_barcode_edit_dist_cols(annotated_read),
+
+                # Edit distances for fixed sequences (p7, RP1, RP2, p5, etc.)
+                **get_fixed_seq_edit_dist_cols(annotated_read),
+
+                'base_qualities': base_qualities[i] if output_fmt == "fastq" else None,
+                'architecture': annotated_read['architecture'],
+                'reason': annotated_read['reason'],
+                'orientation': annotated_read['orientation']
+            }
+            for i, annotated_read in enumerate(chunk_contiguous_annotated_sequences)
+        )
+    )
+
+    # Filter out invalid reads
+    invalid_reads_df = chunk_df[chunk_df['architecture'] == 'invalid']
+    valid_reads_df = chunk_df[chunk_df['architecture'] != 'invalid']
+
+    if model_type == "HYB" and pass_num == 1:
+        tmp_invalid_dir = os.path.join(output_dir, "tmp_invalid_reads")
+        os.makedirs(tmp_invalid_dir, exist_ok=True)
+
+        tmp_invalid_df = pl.DataFrame({
+            'ReadName': invalid_reads_df['ReadName'],
+            'read': invalid_reads_df['read'],
+            'read_length': invalid_reads_df['read_length']
+        })
+
+        tmp_path = f'{tmp_invalid_dir}/{bin_name}.tsv'
+        lock_path = f"{tmp_path}.lock"
+
+        if not os.path.exists(lock_path):
+            with open(lock_path, 'w') as lock_file:
+                lock_file.write('')
+
+        with FileLock(lock_path):
+            write_header = not os.path.exists(tmp_path)
+            with open(tmp_path, 'a', newline='') as f:
+                writer = csv.writer(f, delimiter='\t')
+                if write_header:
+                    writer.writerow(tmp_invalid_df.columns)
+                writer.writerows(tmp_invalid_df.rows())
+
+    else:
+        if not invalid_reads_df.empty:
+            with invalid_file_lock:
+                add_header = not os.path.exists(invalid_output_file) or os.path.getsize(invalid_output_file) == 0
+                invalid_reads_df.to_csv(invalid_output_file, sep='\t', index=False, mode='a', header=add_header)
+
+    # Process valid reads for barcodes
+    column_mapping = {}
+    for barcode in barcodes:
+        column_mapping[barcode] = barcode
+
+    # Process barcodes in parallel
+    if not valid_reads_df.empty:
+        corrected_df, match_type_counts, cell_id_counts = bc_n_demultiplex(
+            valid_reads_df, strand,
+            list(column_mapping.keys()),
+            whitelist_dict, whitelist_df, threshold,
+            output_dir, output_fmt, demuxed_fasta,
+            demuxed_fasta_lock, ambiguous_fasta,
+            ambiguous_fasta_lock, n_jobs
+        )
+
+        # Compute barcode stats
+        for barcode in list(column_mapping.keys()):
+            count_column = f'corrected_{barcode}_counts_with_min_dist'
+            min_dist_column = f'corrected_{barcode}_min_dist'
+
+            # Update count stats
+            chunk_count_data = corrected_df[count_column].value_counts()
+            for key, value in chunk_count_data.items():
+                cumulative_barcodes_stats[barcode]['count_data'][key] = (
+                    cumulative_barcodes_stats[barcode]['count_data'].get(key, 0) + value
+                )
+
+            # Update min distance stats
+            chunk_min_dist_data = corrected_df[min_dist_column].value_counts()
+            for key, value in chunk_min_dist_data.items():
+                cumulative_barcodes_stats[barcode]['min_dist_data'][key] = (
+                    cumulative_barcodes_stats[barcode]['min_dist_data'].get(key, 0) + value
+                )
+
+        # Save valid reads with all edit distance columns
+        with valid_file_lock:
+            add_header = not os.path.exists(valid_output_file) or os.path.getsize(valid_output_file) == 0
+            corrected_df.to_csv(valid_output_file, sep='\t', index=False, mode='a', header=add_header)
+
+        logging.info(f"Post-processed {bin_name} chunk - {chunk_idx}: number of reads = {reads_in_chunk}")
+
+        return match_type_counts, cell_id_counts, cumulative_barcodes_stats
+
+    for local_df in ["chunk_df", "corrected_df", "invalid_reads_df", "valid_reads_df"]:
+        if local_df:
+            del local_df
+
+    gc.collect()
+    tf.keras.backend.clear_session()
+    gc.collect()
+
+
+def post_process_reads(reads, read_names, strand, output_fmt,
+                       base_qualities, model_type, pass_num,
+                       model_path_w_CRF, predictions, label_binarizer,
+                       cumulative_barcodes_stats, read_lengths,
+                       seq_order, add_header, bin_name, chunk_idx, output_dir,
+                       invalid_output_file, invalid_file_lock,
+                       valid_output_file, valid_file_lock, barcodes,
+                       whitelist_df, whitelist_dict, threshold,
+                       checkpoint_file, chunk_start, match_type_counter,
+                       cell_id_counter, demuxed_fasta, demuxed_fasta_lock,
+                       ambiguous_fasta, ambiguous_fasta_lock, njobs,
+                       seq_orders_path=None, model_name=None, whitelist_base_dir=None):
+
+    results = process_full_length_reads_in_chunks_and_save(
+        reads, read_names, strand, output_fmt,
+        base_qualities, model_type, pass_num,
+        model_path_w_CRF, predictions,
+        bin_name, chunk_idx,
+        label_binarizer, cumulative_barcodes_stats,
+        read_lengths, seq_order,
+        add_header, output_dir,
+        invalid_output_file, invalid_file_lock,
+        valid_output_file, valid_file_lock,
+        barcodes, whitelist_df, whitelist_dict,
+        demuxed_fasta, demuxed_fasta_lock,
+        ambiguous_fasta, ambiguous_fasta_lock,
+        threshold, njobs,
+        seq_orders_path, model_name, whitelist_base_dir
+    )
+
+    if results is not None:
+        match_type_counts, cell_id_counts, cumulative_barcodes_stats = results
+
+        for key, value in match_type_counts.items():
+            match_type_counter[key] += value
+        for key, value in cell_id_counts.items():
+            cell_id_counter[key] += value
+
+    save_checkpoint(checkpoint_file, bin_name, chunk_start)
+
+    gc.collect()
+
+    return cumulative_barcodes_stats, match_type_counter, cell_id_counter
+
+
+def filtering_reason_stats(reason_counter_by_bin, output_dir):
+
+    raw_counts_df = pd.DataFrame.from_dict(reason_counter_by_bin, orient='index').fillna(0).T
+    total_reads = raw_counts_df.sum(axis=0)
+    normalized_data = raw_counts_df.div(total_reads, axis=1)
+
+    raw_counts_df.to_csv(f"{output_dir}/filtered_raw_counts_by_bins.tsv", sep='\t')
+    normalized_data.to_csv(f"{output_dir}/filtered_normalized_fractions_by_bins.tsv", sep='\t')
+
+    print(f"Saved raw counts to {output_dir}/filtered_raw_counts_by_bins.tsv")
+    print(f"Saved normalized fractions to {output_dir}/filtered_normalized_fractions_by_bins.tsv")
+
+
+def plot_read_n_cDNA_lengths(output_dir):
+    df = pl.read_parquet(f"{output_dir}/annotations_valid.parquet",
+                         columns=["read_length", "cDNA_length"])
+    read_lengths = []
+    cDNA_lengths = []
+
+    read_lengths.extend(df["read_length"].to_list())
+    read_lengths = np.array(read_lengths, dtype=int)
+
+    cDNA_lengths.extend(df["cDNA_length"].to_list())
+    cDNA_lengths = np.array(cDNA_lengths, dtype=int)
+
+    log_read_lengths = np.log10(read_lengths[read_lengths > 0])
+    log_cDNA_lengths = np.log10(cDNA_lengths[cDNA_lengths > 0])
+
+    with PdfPages(f"{output_dir}/plots/cDNA_len_distr.pdf") as pdf:
+        if len(log_read_lengths[log_read_lengths > 0]):
+            plt.figure(figsize=(8, 6))
+            plt.hist(log_read_lengths[log_read_lengths > 0],
+                     bins=100, color='blue', edgecolor='black')
+            plt.title('Read Length Distribution (Log Scale)')
+            plt.xlabel('Log10(Read Length)')
+            plt.ylabel('Frequency')
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+        if len(log_cDNA_lengths[log_cDNA_lengths > 0]):
+            plt.figure(figsize=(8, 6))
+            plt.hist(log_cDNA_lengths[log_cDNA_lengths > 0],
+                     bins=100, color='blue', edgecolor='black')
+            plt.title('cDNA Length Distribution (Log Scale)')
+            plt.xlabel('Log10(cDNA Length)')
+            plt.ylabel('Frequency')
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()

--- a/scripts/extract_annotated_seqs.py
+++ b/scripts/extract_annotated_seqs.py
@@ -189,9 +189,18 @@ def process_full_len_reads(data, barcodes, label_binarizer, model_path_w_CRF):
     annotations['orientation'] = order
     annotations["reason"] = reasons
 
-    if annotations["architecture"] == "valid":
-        for barcode in barcodes:
-            annotations[barcode]["Sequences"] = [read[int(annotations[barcode]['Starts'][0]):int(annotations[barcode]['Ends'][0])]]
+    # Extract sequences for ALL segments in ALL reads (valid and invalid)
+    # This allows inspection of what the model detected, including segment lengths and edit distances
+    # Keep full sequences here for accurate edit distance calculation
+    # Truncation for display will happen later in the export process
+    # Yes, this is extra overhead, but is necessary for now. Can disable in the future.
+    for segment in seq_order:
+        if segment in annotations and annotations[segment].get('Starts') and annotations[segment].get('Ends'):
+            if annotations[segment]['Starts']:  # Check if list is not empty
+                start_pos = int(annotations[segment]['Starts'][0])
+                end_pos = int(annotations[segment]['Ends'][0])
+                full_seq = read[start_pos:end_pos]
+                annotations[segment]["Sequences"] = [full_seq]
 
     return annotations
 

--- a/scripts/trained_models.py
+++ b/scripts/trained_models.py
@@ -59,49 +59,106 @@ def trained_models():
 
 
 def seq_orders(file_path, model):
-    try:
-        # Check if the file exists
-        if not os.path.isfile(file_path):
-            print(f"The file '{file_path}' does not exist.")
-            return
+    """
+    Load model configuration from seq_orders.tsv file.
 
-        sequence_order = []
-        sequences = []
-        barcodes = []
-        UMIs = []
-        strand = ""
+    Args:
+        file_path: Path to seq_orders.tsv file
+        model: Model name to look up
 
-        # Open the file and read lines
-        with open(file_path, 'r') as file:
-            for line in file:
-                # Split the line by tabs, removing extra quote characters at the same time
-                fields = line.strip().replace("'", "").replace("\"", "").split("\t")
+    Returns:
+        Tuple of (sequence_order, sequences, barcodes, UMIs, strand)
 
-                # Check if desired model has been found
-                # If so, process rest of the line
-                model_name = fields[0].strip()
-                if model_name == model:
+    Raises:
+        FileNotFoundError: If seq_orders.tsv file doesn't exist
+        ValueError: If model not found or entry is malformed
+    """
+    # Check if the file exists
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(
+            f"\n{'='*80}\n"
+            f"ERROR: seq_orders.tsv file not found!\n"
+            f"  Expected location: {file_path}\n"
+            f"  \n"
+            f"  This file is required to define model architectures.\n"
+            f"  Please ensure the file exists or specify a custom path with --seq-order-file\n"
+            f"{'='*80}"
+        )
+
+    # Track all available models for error message
+    available_models = []
+
+    # Open the file and read lines
+    with open(file_path, 'r') as file:
+        for line_num, line in enumerate(file, 1):
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            # Split the line by tabs, removing extra quote characters at the same time
+            fields = line.replace("'", "").replace("\"", "").split("\t")
+
+            if len(fields) < 1:
+                continue
+
+            model_name = fields[0].strip()
+            available_models.append(model_name)
+
+            # Check if desired model has been found
+            if model_name == model:
+                # Validate we have all required fields
+                if len(fields) < 5:
+                    raise ValueError(
+                        f"\n{'='*80}\n"
+                        f"ERROR: Malformed entry for model '{model}' in seq_orders.tsv!\n"
+                        f"  Location: {file_path}, line {line_num}\n"
+                        f"  \n"
+                        f"  Expected format (tab-separated):\n"
+                        f"    model_name<TAB>segment_order<TAB>sequences<TAB>barcodes<TAB>UMIs<TAB>strand\n"
+                        f"  \n"
+                        f"  Found {len(fields)} fields, expected at least 5.\n"
+                        f"  Fields found: {fields}\n"
+                        f"  \n"
+                        f"  Missing: {', '.join(['segment_order', 'sequences', 'barcodes', 'UMIs', 'strand'][len(fields)-1:])}\n"
+                        f"{'='*80}"
+                    )
+
+                try:
                     sequence_order = fields[1].strip().split(',')
                     sequences = fields[2].strip().split(',')
                     barcodes = fields[3].strip().split(',')
                     UMIs = fields[4].strip().split(',')
-                    strand = fields[5].strip()
+                    # Strand is optional (default to empty string if not provided)
+                    strand = fields[5].strip() if len(fields) > 5 else ""
 
                     return sequence_order, sequences, barcodes, UMIs, strand
 
-                # Model name not found on this line, moving to the next one
+                except IndexError as e:
+                    raise ValueError(
+                        f"\n{'='*80}\n"
+                        f"ERROR: Failed to parse model '{model}' from seq_orders.tsv!\n"
+                        f"  Location: {file_path}, line {line_num}\n"
+                        f"  \n"
+                        f"  Error: {str(e)}\n"
+                        f"  Line content: {line}\n"
+                        f"{'='*80}"
+                    )
 
-        # If we make it here, requested model was not found
-        # Verify just to be sure though
-        if len(sequence_order) == 0:
-            # TODO: A more well-rounded error handling set up needs to be developed
-            #       This gets the job done as trying to unpack None into a tuple causes an error,
-            #       but this isn't an ideal long term solution
-            raise Exception(f"Requested model ({model}) not found")
-
-    # Because we're catching the exception we just raised, this message will always print, even if we're
-    # "handling" things downstream. This really needs an error handling system set up
-    except Exception as e:
-        print(f"An error occurred: {e}")
+    # If we make it here, requested model was not found
+    raise ValueError(
+        f"\n{'='*80}\n"
+        f"ERROR: Model '{model}' not found in seq_orders.tsv!\n"
+        f"  File: {file_path}\n"
+        f"  \n"
+        f"  Available models ({len(available_models)}):\n"
+        f"    {', '.join(sorted(available_models))}\n"
+        f"  \n"
+        f"  To add your model, add a line to seq_orders.tsv with this format:\n"
+        f"    {model}<TAB>segment_order<TAB>sequences<TAB>barcodes<TAB>UMIs<TAB>strand\n"
+        f"  \n"
+        f"  Example:\n"
+        f"    {model}<TAB>\"p7,CBC,cDNA,p5\"<TAB>\"ACGT,N16,NN,TGCA\"<TAB>CBC<TAB><TAB>fwd\n"
+        f"{'='*80}"
+    )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import importlib.util
+import site
+import sys
+import types
+import pytest
+from pathlib import Path
+
+# Prefer an installed tranquillyzer; fall back to local source when not available.
+if importlib.util.find_spec("tranquillyzer") is None:
+    site.addsitedir(str(Path(__file__).resolve().parent.parent))
+
+# Provide lightweight tensorflow stub if not installed to keep unit tests fast.
+if importlib.util.find_spec("tensorflow") is None:
+    tf_stub = types.ModuleType("tensorflow")
+    tf_stub.keras = types.SimpleNamespace(backend=types.SimpleNamespace(clear_session=lambda: None))
+    sys.modules.setdefault("tensorflow", tf_stub)
+
+
+@pytest.fixture
+def fake_tf(monkeypatch):
+    """Alias for monkeypatch to avoid TF-heavy dependency name leakage in tests."""
+    return monkeypatch

--- a/tests/unit/test_annotate_reads_wrap.py
+++ b/tests/unit/test_annotate_reads_wrap.py
@@ -1,0 +1,9 @@
+import inspect
+
+import wrappers.annotate_reads_wrap as ann
+
+
+def test_include_flags_defaults_off():
+    sig = inspect.signature(ann.annotate_reads_wrap)
+    assert sig.parameters['include_edit_distances'].default is False
+    assert sig.parameters['include_sequences_in_valid_output'].default is False

--- a/tests/unit/test_export_annotations_with_edit_distances.py
+++ b/tests/unit/test_export_annotations_with_edit_distances.py
@@ -1,0 +1,108 @@
+import sys
+import types
+from collections import defaultdict
+
+import pandas as pd
+from filelock import FileLock
+
+# Provide a lightweight tensorflow stub to satisfy imports without heavyweight dependency
+tf_stub = types.ModuleType("tensorflow")
+tf_stub.keras = types.SimpleNamespace(backend=types.SimpleNamespace(clear_session=lambda: None))
+sys.modules.setdefault("tensorflow", tf_stub)
+
+import scripts.export_annotations_with_edit_distances as exp
+
+
+def _run_process_with_flags(tmp_path, include_edit, include_seqs, fake_tf):
+    # Minimal annotated read payload
+    annotated_reads = [{
+        'read_length': 4,
+        'read': 'ACTG',
+        'architecture': 'valid',
+        'reason': 'ok',
+        'orientation': '+',
+        'CBC': {'Starts': [0], 'Ends': [3], 'Sequences': ['ACT']},
+        'cDNA': {'Starts': [0], 'Ends': [4]},
+        'UMI': {'Starts': [0], 'Ends': [2]},
+    }]
+
+    def fake_extract(*_args, **_kwargs):
+        return annotated_reads
+
+    def fake_whitelists(*_args, **_kwargs):
+        return ({'CBC': ['ACT']}, {}) if include_edit else ({}, {})
+
+    def fake_bc(valid_reads_df, _strand, barcode_columns, *_rest):
+        corrected = pd.DataFrame({
+            'ReadName': valid_reads_df['ReadName'],
+            'read_length': valid_reads_df['read_length'],
+            'architecture': valid_reads_df['architecture'],
+            'reason': valid_reads_df['reason'],
+            'orientation': valid_reads_df['orientation'],
+        })
+        for barcode in barcode_columns:
+            corrected[f'corrected_{barcode}_counts_with_min_dist'] = [1] * len(corrected)
+            corrected[f'corrected_{barcode}_min_dist'] = [0] * len(corrected)
+        return corrected, defaultdict(int), defaultdict(int)
+
+    fake_tf.setattr(exp, "extract_annotated_full_length_seqs", fake_extract)
+    fake_tf.setattr(exp, "get_or_load_whitelists_and_sequences", fake_whitelists)
+    fake_tf.setattr(exp, "bc_n_demultiplex", fake_bc)
+
+    config = exp.AnnotateReadsConfig(
+        output_fmt="fasta",
+        model_type="REG",
+        pass_num=1,
+        model_path_w_CRF="",
+        threshold=0,
+        n_jobs=1,
+        include_edit_distances=include_edit,
+        include_sequences_in_valid_output=include_seqs,
+    )
+
+    output_dir = tmp_path
+    valid_output_file = output_dir / "valid.tsv"
+    invalid_output_file = output_dir / "invalid.tsv"
+
+    exp.process_full_length_reads_in_chunks_and_save(
+        config=config,
+        reads=["ACTG"],
+        original_read_names=["read1"],
+        strand="fwd",
+        base_qualities=["!!!!"],
+        predictions=None,
+        bin_name="bin1",
+        chunk_idx=1,
+        label_binarizer=None,
+        cumulative_barcodes_stats={'CBC': {'count_data': {}, 'min_dist_data': {}}},
+        actual_lengths=[4],
+        seq_order=[],
+        add_header=True,
+        output_dir=str(output_dir),
+        invalid_output_file=str(invalid_output_file),
+        invalid_file_lock=FileLock(str(invalid_output_file) + ".lock"),
+        valid_output_file=str(valid_output_file),
+        valid_file_lock=FileLock(str(valid_output_file) + ".lock"),
+        barcodes=["CBC"],
+        whitelist_df=pd.DataFrame(),
+        whitelist_dict={},
+        demuxed_fasta=str(output_dir / "demux.fa"),
+        demuxed_fasta_lock=FileLock(str(output_dir / "demux.fa") + ".lock"),
+        ambiguous_fasta=str(output_dir / "amb.fa"),
+        ambiguous_fasta_lock=FileLock(str(output_dir / "amb.fa") + ".lock"),
+    )
+
+    return pd.read_csv(valid_output_file, sep='\t').columns.tolist()
+
+
+def test_process_flags_exclude_optional_columns(tmp_path, fake_tf):
+    cols = _run_process_with_flags(tmp_path, include_edit=False, include_seqs=False, fake_tf=fake_tf)
+    assert 'read' not in cols
+    assert not any(col.endswith('_edit_distance') for col in cols)
+
+
+def test_process_flags_include_optional_columns(tmp_path, fake_tf):
+    cols = _run_process_with_flags(tmp_path, include_edit=True, include_seqs=True, fake_tf=fake_tf)
+    assert 'read' in cols
+    assert 'CBC_edit_distance' in cols
+    assert 'CBC_match_orientation' in cols

--- a/tests/unit/test_whitelist_overrides.py
+++ b/tests/unit/test_whitelist_overrides.py
@@ -43,7 +43,6 @@ def test_explicit_whitelists_respect_seq_order(tmp_path):
     whitelists, known = exp.get_or_load_whitelists_and_sequences(
         seq_orders_path=str(seq_orders_path),
         model_name="modelA",
-        whitelist_base_dir=None,
         whitelist_df=None,
         metadata_path=None,
         sample_id=None,

--- a/tests/unit/test_whitelist_overrides.py
+++ b/tests/unit/test_whitelist_overrides.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+
+from main import parse_whitelist_arg
+import scripts.export_annotations_with_edit_distances as exp
+
+
+def reset_whitelist_cache():
+    exp._CACHED_WHITELISTS = None
+    exp._CACHED_KNOWN_SEQUENCES = None
+    exp._CURRENT_CACHED_SAMPLE_ID = None
+    exp._CACHED_WHITELIST_PATHS = None
+
+
+def write_seq_orders(tmp_path: Path, model: str, segments: str, sequences: str = "AAA,BBB"):
+    seq_orders = tmp_path / "seq_orders.tsv"
+    seq_orders.write_text(f'{model}\t"{segments}"\t"{sequences}"\n')
+    return seq_orders
+
+
+def test_parse_whitelist_arg_roundtrip(tmp_path):
+    path1 = tmp_path / "a.txt"
+    path2 = tmp_path / "b.txt"
+    result = parse_whitelist_arg(f"seg1:{path1},seg2:{path2}")
+    assert result == {"seg1": str(path1), "seg2": str(path2)}
+
+    with pytest.raises(ValueError):
+        parse_whitelist_arg("missingcolon")
+
+
+def test_explicit_whitelists_respect_seq_order(tmp_path):
+    # Use variable-length patterns so segments remain eligible for whitelist lookup
+    seq_orders_path = write_seq_orders(tmp_path, "modelA", "seg1,seg2", sequences="NN,NN")
+
+    # Write whitelist only for seg1; segX should be ignored because it's not in seq_orders
+    seg1_file = tmp_path / "seg1.txt"
+    seg1_file.write_text("id\tACT\n")
+    segx_file = tmp_path / "segX.txt"
+    segx_file.write_text("id\tAAA\n")
+
+    reset_whitelist_cache()
+    whitelists, known = exp.get_or_load_whitelists_and_sequences(
+        seq_orders_path=str(seq_orders_path),
+        model_name="modelA",
+        whitelist_base_dir=None,
+        whitelist_df=None,
+        metadata_path=None,
+        sample_id=None,
+        whitelist_paths={"seg1": str(seg1_file), "segX": str(segx_file)},
+    )
+
+    assert whitelists.get("seg1") == ["ACT"]
+    assert "segX" not in whitelists

--- a/utils/analyze_edit_distances.py
+++ b/utils/analyze_edit_distances.py
@@ -1,203 +1,534 @@
 #!/usr/bin/env python3
 """
-Analyze edit distance distributions for valid reads with ONT-specific thresholds.
-
-This script reads the annotations parquet file and generates:
-1. Summary statistics for edit distances per segment
-2. ONT-aware filtering thresholds based on segment length and expected error rates
-3. Visualizations of edit distance distributions
-4. Recommendations for filtering thresholds
+Polars-based edit distance analysis with streaming for large datasets.
 
 Usage:
-    python analyze_edit_distances.py <parquet_file> [--output_dir OUTPUT_DIR] [--ont_error_rate ONT_ERROR_RATE]
+    # Analyze valid reads only
+    python analyze_edit_distances.py <valid_parquet> [--ont_error_rate 0.05] [--sample_size 10000]
+
+    # Compare valid and invalid reads
+    python analyze_edit_distances.py <valid_parquet> --invalid_parquet <invalid_parquet> [options]
 """
 
-import os
-import sys
 import argparse
-import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-from matplotlib.backends.backend_pdf import PdfPages
+import sys
 from pathlib import Path
 from math import ceil
 
+import polars as pl
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.patches import Patch
+from matplotlib.lines import Line2D
+
 sns.set_style("whitegrid")
 
-def load_valid_reads(parquet_file):
-    """Load valid reads from parquet file."""
-    print(f"Loading data from {parquet_file}...")
+# Helpers
 
-    # Try polars first (faster), fall back to pandas if needed
-    try:
-        import polars as pl
-        df = pl.read_parquet(parquet_file)
-        # Convert to pandas for easier manipulation
-        df = df.to_pandas()
-    except Exception as e:
-        print(f"Polars not available or failed ({e}), using pandas...")
-        df = pd.read_parquet(parquet_file)
+def is_concatenated_read(lf):
+    """
+    Detect concatenated reads by checking for comma-separated values in Starts/Ends fields.
+    Returns a boolean expression identifying concatenated reads.
+    """
+    # Check if any segment has comma-separated starts (indicating multiple instances)
+    schema = lf.collect_schema()
+    concat_checks = []
 
-    print(f"Loaded {len(df):,} reads")
-    return df
+    for col in schema:
+        if col.endswith("_Starts") or col.endswith("_Ends"):
+            concat_checks.append(
+                pl.col(col).cast(pl.Utf8).str.contains(",")
+            )
 
-def identify_edit_distance_columns(df):
-    """Identify all edit distance columns in the DataFrame."""
-    edit_dist_cols = [col for col in df.columns if col.endswith('_edit_distance')]
+    if concat_checks:
+        # True if ANY segment field contains commas
+        return pl.any_horizontal(concat_checks).fill_null(False)
+    else:
+        return pl.lit(False)
 
-    # Categorize by segment type
-    barcode_segments = []
-    fixed_segments = []
 
-    for col in edit_dist_cols:
-        segment = col.replace('_edit_distance', '')
-        if segment in ['CBC', 'i7', 'i5']:
-            barcode_segments.append(segment)
-        else:
-            fixed_segments.append(segment)
+def add_segment_scores(lf, segments, segment_lengths):
+    """
+    Add inverted normalized edit distance scores for each segment.
 
-    return edit_dist_cols, barcode_segments, fixed_segments
+    Score = 1.0 - (edit_distance / segment_length)
+    - 1.0 = perfect match (0 edit distance)
+    - 0.0 = worst possible (edit distance >= segment length)
+    - NMF and concatenated reads get null scores
 
-def get_segment_lengths(df, segments):
-    """Calculate median segment length for each segment."""
-    segment_lengths = {}
+    Returns LazyFrame with added score columns.
+    """
+    # Identify concatenated reads
+    is_concat = is_concatenated_read(lf)
 
-    for segment in segments:
-        start_col = f'{segment}_Starts'
-        end_col = f'{segment}_Ends'
+    score_exprs = []
 
-        if start_col in df.columns and end_col in df.columns:
-            # Calculate lengths where both start and end are present
-            lengths = df[end_col] - df[start_col]
-            lengths = lengths[lengths > 0]  # Filter out invalid lengths
+    for seg in segments:
+        ed_col = f"{seg}_edit_distance"
+        length = segment_lengths.get(seg)
 
-            if len(lengths) > 0:
-                segment_lengths[segment] = lengths.median()
-            else:
-                # Fallback: estimate from sequence column if available
-                seq_col = f'{segment}_Sequences'
-                if seq_col in df.columns:
-                    seq_lengths = df[seq_col].dropna().str.len()
-                    if len(seq_lengths) > 0:
-                        segment_lengths[segment] = seq_lengths.median()
+        if length is None or length == 0:
+            continue
 
-    return segment_lengths
+        # Inverted normalized score: 1.0 = perfect, 0.0 = worst
+        score_expr = (
+            pl.when(is_concat)
+            .then(None)  # Skip concatenated reads
+            .when(pl.col(ed_col) == "NMF")
+            .then(None)  # Skip undetected segments
+            .otherwise(
+                (1.0 - (
+                    pl.col(ed_col)
+                    .cast(pl.Float32, strict=False)
+                    / pl.lit(float(length))
+                )).clip(0.0, 1.0)  # Clamp to [0, 1]
+            )
+            .alias(f"{seg}_score")
+        )
+        score_exprs.append(score_expr)
+
+    # Add all score columns
+    if score_exprs:
+        lf = lf.with_columns(score_exprs)
+
+        # Add composite read-level quality score (mean across all segment scores)
+        score_cols = [f"{seg}_score" for seg in segments if segment_lengths.get(seg)]
+        lf = lf.with_columns([
+            pl.mean_horizontal(score_cols).alias("read_quality_score")
+        ])
+
+    return lf
+
 
 def calculate_ont_threshold(segment_length, error_rate):
-    """
-    Calculate acceptable edit distance based on ONT error rate and segment length.
-
-    For ONT data with error_rate (e.g., 0.05 for 5%), the maximum acceptable
-    edit distance is: ceil(segment_length * error_rate)
-    """
+    """Calculate acceptable edit distance based on ONT error rate and segment length."""
     if segment_length is None or segment_length == 0:
         return None
     return ceil(segment_length * error_rate)
 
-def calculate_statistics(df, segment, edit_dist_col, segment_length=None, ont_error_rate=0.05):
-    """Calculate comprehensive statistics for a segment's edit distances."""
-    values = df[edit_dist_col].dropna()
+# Identify edit distance columns
 
-    if len(values) == 0:
-        return None
+def identify_edit_distance_columns(schema):
+    """Identify edit distance columns and categorize segments."""
+    edit_cols = [c for c in schema if c.endswith("_edit_distance")]
 
-    # Calculate ONT-aware threshold if segment length is available
-    ont_threshold_strict = calculate_ont_threshold(segment_length, 0.02) if segment_length else None  # 2% error
-    ont_threshold_permissive = calculate_ont_threshold(segment_length, ont_error_rate) if segment_length else None  # User-specified (default 5%)
-    ont_threshold_very_permissive = calculate_ont_threshold(segment_length, 0.10) if segment_length else None  # 10% error
+    barcode_segments = []
+    fixed_segments = []
 
-    stats = {
-        'segment': segment,
-        'median_length': segment_length if segment_length else np.nan,
-        'total_reads': len(df),
-        'reads_with_segment': len(values),
-        'reads_missing_segment': len(df) - len(values),
-        'percent_detected': 100 * len(values) / len(df),
+    for col in edit_cols:
+        segment = col.replace("_edit_distance", "")
+        if segment in ("CBC", "i7", "i5"):
+            barcode_segments.append(segment)
+        else:
+            fixed_segments.append(segment)
+
+    return edit_cols, barcode_segments, fixed_segments
+
+# Estimate segment lengths efficiently by sampling
+
+def compute_segment_lengths(lf, segments, sample_size=10_000):
+    """
+    Estimate median segment lengths using streaming-friendly sampling.
+
+    Args:
+        lf: LazyFrame with annotation data
+        segments: List of segment names
+        sample_size: Number of rows to sample
+
+    Returns:
+        Dictionary mapping segment names to median lengths
+    """
+    print(f"  Sampling {sample_size:,} reads for length estimation...")
+
+    # Get total rows for sampling calculation
+    total_rows = lf.select(pl.len()).collect().item()
+
+    if total_rows > sample_size:
+        # Sample evenly across file
+        skip = max(1, total_rows // sample_size)
+        df_sample = (
+            lf.with_row_index("_idx")
+            .filter(pl.col("_idx") % skip == 0)
+            .head(sample_size)
+            .collect(engine="streaming")
+        )
+        print(f"  (from {total_rows:,} total reads)")
+    else:
+        df_sample = lf.collect(engine="streaming")
+
+    lengths = {}
+
+    for seg in segments:
+        start_col = f"{seg}_Starts"
+        end_col = f"{seg}_Ends"
+        seq_col = f"{seg}_Sequences"
+
+        length = None
+
+        # Try Start/End positions first
+        if start_col in df_sample.columns and end_col in df_sample.columns:
+            # Handle comma-separated values (e.g., "100, 200") by taking first
+            starts = (
+                df_sample[start_col]
+                .cast(pl.Utf8)
+                .str.split(",")
+                .list.first()
+                .str.strip_chars()
+                .cast(pl.Int64, strict=False)
+            )
+            ends = (
+                df_sample[end_col]
+                .cast(pl.Utf8)
+                .str.split(",")
+                .list.first()
+                .str.strip_chars()
+                .cast(pl.Int64, strict=False)
+            )
+
+            # Calculate lengths (filter out nulls and negatives)
+            diffs = (ends - starts).filter(
+                starts.is_not_null() &
+                ends.is_not_null() &
+                ((ends - starts) > 0)
+            )
+
+            if len(diffs) > 0:
+                length = diffs.median()
+
+        # Fallback: estimate from sequence column
+        if length is None and seq_col in df_sample.columns:
+            seq_lengths = df_sample[seq_col].str.len_bytes().drop_nulls()
+            if len(seq_lengths) > 0:
+                length = seq_lengths.median()
+
+        lengths[seg] = length
+
+    return lengths
+
+
+def add_segment_length_columns(lf, segments):
+    """
+    Add actual segment length columns (not just median) for distribution analysis.
+
+    Returns LazyFrame with {segment}_length columns added.
+    """
+    length_exprs = []
+
+    for seg in segments:
+        start_col = f"{seg}_Starts"
+        end_col = f"{seg}_Ends"
+        seq_col = f"{seg}_Sequences"
+
+        # Try Start/End positions first
+        if start_col in lf.collect_schema() and end_col in lf.collect_schema():
+            # Handle comma-separated values by taking first
+            length_expr = (
+                pl.when(
+                    pl.col(start_col).cast(pl.Utf8).str.contains(",").fill_null(False)
+                )
+                .then(None)  # Skip concatenated reads
+                .otherwise(
+                    (
+                        pl.col(end_col).cast(pl.Utf8).str.split(",").list.first().str.strip_chars().cast(pl.Int64, strict=False)
+                        - pl.col(start_col).cast(pl.Utf8).str.split(",").list.first().str.strip_chars().cast(pl.Int64, strict=False)
+                    )
+                )
+                .alias(f"{seg}_length")
+            )
+            length_exprs.append(length_expr)
+        # Fallback: use sequence length
+        elif seq_col in lf.collect_schema():
+            length_expr = (
+                pl.col(seq_col)
+                .str.len_bytes()
+                .alias(f"{seg}_length")
+            )
+            length_exprs.append(length_expr)
+
+    if length_exprs:
+        lf = lf.with_columns(length_exprs)
+
+    return lf
+
+
+def compute_segment_length_statistics(lf, segments, median_lengths, anomaly_thresholds=None):
+    """
+    Compute comprehensive length statistics for each segment.
+
+    Args:
+        lf: LazyFrame with segment length columns
+        segments: List of segment names
+        median_lengths: Dictionary of median segment lengths
+        anomaly_thresholds: Dictionary of minimum expected lengths per segment (e.g., {'cDNA': 50, 'polyA': 10})
+
+    Returns DataFrame with length statistics per segment.
+    """
+    print("\nCalculating segment length statistics...")
+
+    if anomaly_thresholds is None:
+        anomaly_thresholds = {}
+
+    all_length_stats = []
+
+    for seg in segments:
+        length_col = f"{seg}_length"
+
+        if length_col not in lf.collect_schema():
+            continue
+
+        median_length = median_lengths.get(seg)
+        min_expected = anomaly_thresholds.get(seg)
+
+        # Compute statistics
+        stats_expr = [
+            pl.col(length_col).count().alias("reads_with_length"),
+            pl.col(length_col).mean().alias("mean_length"),
+            pl.col(length_col).median().alias("median_length"),
+            pl.col(length_col).std().alias("std_length"),
+            pl.col(length_col).min().alias("min_length"),
+            pl.col(length_col).max().alias("max_length"),
+            pl.col(length_col).quantile(0.01, "nearest").alias("p01_length"),
+            pl.col(length_col).quantile(0.05, "nearest").alias("p05_length"),
+            pl.col(length_col).quantile(0.25, "nearest").alias("p25_length"),
+            pl.col(length_col).quantile(0.75, "nearest").alias("p75_length"),
+            pl.col(length_col).quantile(0.95, "nearest").alias("p95_length"),
+            pl.col(length_col).quantile(0.99, "nearest").alias("p99_length"),
+        ]
+
+        result = lf.select(stats_expr).collect().to_dicts()[0]
+
+        # Calculate outliers (>2 std from median)
+        if median_length and result["std_length"]:
+            lower_bound = median_length - 2 * result["std_length"]
+            upper_bound = median_length + 2 * result["std_length"]
+
+            outlier_count = lf.filter(
+                (pl.col(length_col).cast(pl.Int64, strict=False) < lower_bound) |
+                (pl.col(length_col).cast(pl.Int64, strict=False) > upper_bound)
+            ).select(pl.len()).collect().item()
+
+            outlier_pct = 100 * outlier_count / result["reads_with_length"] if result["reads_with_length"] > 0 else 0
+        else:
+            outlier_count = None
+            outlier_pct = None
+            lower_bound = None
+            upper_bound = None
+
+        # Detect anomalies (very short segments)
+        anomaly_count = None
+        anomaly_pct = None
+        if min_expected is not None:
+            anomaly_count = lf.filter(
+                (pl.col(length_col).cast(pl.Int64, strict=False).is_not_null()) &
+                (pl.col(length_col).cast(pl.Int64, strict=False) < min_expected)
+            ).select(pl.len()).collect().item()
+
+            anomaly_pct = 100 * anomaly_count / result["reads_with_length"] if result["reads_with_length"] > 0 else 0
+
+        stats = {
+            "segment": seg,
+            "reads_with_length": result["reads_with_length"],
+            "mean_length": result["mean_length"],
+            "median_length": result["median_length"],
+            "std_length": result["std_length"],
+            "min_length": result["min_length"],
+            "max_length": result["max_length"],
+            "p01_length": result["p01_length"],
+            "p05_length": result["p05_length"],
+            "p25_length": result["p25_length"],
+            "p75_length": result["p75_length"],
+            "p95_length": result["p95_length"],
+            "p99_length": result["p99_length"],
+            "outlier_count": outlier_count,
+            "outlier_percent": outlier_pct,
+            "outlier_lower_bound": lower_bound,
+            "outlier_upper_bound": upper_bound,
+            "min_expected_length": min_expected,
+            "anomaly_count": anomaly_count,
+            "anomaly_percent": anomaly_pct,
+        }
+
+        all_length_stats.append(stats)
+
+        # Print with anomaly info if available
+        if anomaly_count is not None:
+            print(f"  {seg}: mean={result['mean_length']:.1f}bp, std={result['std_length']:.1f}bp, "
+                  f"anomalies (<{min_expected}bp)={anomaly_pct:.1f}% ({anomaly_count:,} reads)" if result['std_length']
+                  else f"  {seg}: mean={result['mean_length']:.1f}bp, anomalies (<{min_expected}bp)={anomaly_pct:.1f}%")
+        else:
+            print(f"  {seg}: mean={result['mean_length']:.1f}bp, std={result['std_length']:.1f}bp" if result['std_length']
+                  else f"  {seg}: mean={result['mean_length']:.1f}bp")
+
+    return pl.DataFrame(all_length_stats)
+
+
+# Compute statistics per segment (streaming-friendly)
+
+def compute_segment_statistics(lf, segment, segment_length, ont_error_rate):
+    """
+    Compute comprehensive statistics for one segment using Polars, handling string-float edit distances robustly.
+
+    Args:
+        lf: LazyFrame with annotation data
+        segment: Segment name
+        segment_length: Median segment length
+        ont_error_rate: Expected ONT error rate
+
+    Returns:
+        Dictionary with statistics
+    """
+    col = f"{segment}_edit_distance"
+
+    # Filter out "NMF" (No Match Found) and convert to integers
+    # Cast string -> float -> round -> int
+    ed_col = (
+        pl.col(col)
+        .cast(pl.Float32, strict=False)
+        .round(0)
+        .cast(pl.Int32, strict=False)
+    )
+
+    # Filter to only valid values (exclude NMF which becomes null after cast)
+    ed_valid = ed_col.filter((pl.col(col) != "NMF") & ed_col.is_not_null())
+
+    # ONT-aware thresholds
+    t2 = calculate_ont_threshold(segment_length, 0.02)
+    t5 = calculate_ont_threshold(segment_length, ont_error_rate)
+    t10 = calculate_ont_threshold(segment_length, 0.10)
+
+    # Aggregation expressions
+    agg_exprs = [
+        pl.len().alias("total_reads"),           # total rows
+        ed_valid.count().alias("reads_with_segment"),
 
         # Basic statistics
-        'mean': values.mean(),
-        'median': values.median(),
-        'std': values.std(),
-        'min': values.min(),
-        'max': values.max(),
+        ed_valid.mean().alias("mean"),
+        ed_valid.median().alias("median"),
+        ed_valid.std().alias("std"),
+        ed_valid.min().alias("min"),
+        ed_valid.max().alias("max"),
 
         # Percentiles
-        'p25': values.quantile(0.25),
-        'p75': values.quantile(0.75),
-        'p95': values.quantile(0.95),
-        'p99': values.quantile(0.99),
+        ed_valid.quantile(0.25, "nearest").alias("p25"),
+        ed_valid.quantile(0.75, "nearest").alias("p75"),
+        ed_valid.quantile(0.95, "nearest").alias("p95"),
+        ed_valid.quantile(0.99, "nearest").alias("p99"),
+
+        # Quality counts
+        (ed_valid == 0).sum().alias("perfect_matches"),
+        (ed_valid <= 1).sum().alias("ed1_or_less"),
+        (ed_valid <= 3).sum().alias("ed3_or_less"),
+        (ed_valid <= 5).sum().alias("ed5_or_less"),
+        (ed_valid <= t2 if t2 is not None else pl.lit(None)).sum().alias("pass_2pct"),
+        (ed_valid <= t5 if t5 is not None else pl.lit(None)).sum().alias("pass_5pct"),
+        (ed_valid <= t10 if t10 is not None else pl.lit(None)).sum().alias("pass_10pct"),
+
+        # NMF (No Match Found) counts
+        (pl.col(col) == "NMF").sum().alias("nmf_count"),
+    ]
+
+    # Compute aggregation
+    result = lf.select(agg_exprs).collect().to_dicts()[0]
+
+    total = result["total_reads"]
+    detected = result["reads_with_segment"]
+
+    stats = {
+        "segment": segment,
+        "median_length": segment_length,
+        "total_reads": total,
+        "reads_with_segment": detected,
+        "reads_missing_segment": total - detected,
+        "percent_detected": 100 * detected / total if total > 0 else None,
+        "nmf_count": result["nmf_count"],
+        "percent_nmf": 100 * result["nmf_count"] / total if total > 0 else None,
+
+        # Basic stats
+        "mean": result["mean"],
+        "median": result["median"],
+        "std": result["std"],
+        "min": result["min"],
+        "max": result["max"],
+
+        # Percentiles
+        "p25": result["p25"],
+        "p75": result["p75"],
+        "p95": result["p95"],
+        "p99": result["p99"],
 
         # Quality metrics
-        'perfect_matches': (values == 0).sum(),
-        'percent_perfect': 100 * (values == 0).sum() / len(values),
-        'edit_dist_1_or_less': (values <= 1).sum(),
-        'percent_ed1_or_less': 100 * (values <= 1).sum() / len(values),
-        'edit_dist_3_or_less': (values <= 3).sum(),
-        'percent_ed3_or_less': 100 * (values <= 3).sum() / len(values),
-        'edit_dist_5_or_less': (values <= 5).sum(),
-        'percent_ed5_or_less': 100 * (values <= 5).sum() / len(values),
+        "perfect_matches": result["perfect_matches"],
+        "percent_perfect": 100 * result["perfect_matches"] / detected if detected > 0 else None,
+        "edit_dist_1_or_less": result["ed1_or_less"],
+        "percent_ed1_or_less": 100 * result["ed1_or_less"] / detected if detected > 0 else None,
+        "edit_dist_3_or_less": result["ed3_or_less"],
+        "percent_ed3_or_less": 100 * result["ed3_or_less"] / detected if detected > 0 else None,
+        "edit_dist_5_or_less": result["ed5_or_less"],
+        "percent_ed5_or_less": 100 * result["ed5_or_less"] / detected if detected > 0 else None,
 
-        # ONT-specific thresholds
-        'ont_threshold_2pct': ont_threshold_strict,
-        'ont_threshold_5pct': ont_threshold_permissive,
-        'ont_threshold_10pct': ont_threshold_very_permissive,
+        # ONT thresholds
+        "ont_threshold_2pct": t2,
+        "ont_threshold_5pct": t5,
+        "ont_threshold_10pct": t10,
+        "percent_passing_2pct": 100 * result["pass_2pct"] / detected if detected > 0 and result["pass_2pct"] is not None else None,
+        "percent_passing_5pct": 100 * result["pass_5pct"] / detected if detected > 0 and result["pass_5pct"] is not None else None,
+        "percent_passing_10pct": 100 * result["pass_10pct"] / detected if detected > 0 and result["pass_10pct"] is not None else None,
     }
-
-    # Calculate percentage of reads passing ONT thresholds
-    if ont_threshold_strict is not None:
-        stats['percent_passing_2pct'] = 100 * (values <= ont_threshold_strict).sum() / len(values)
-    else:
-        stats['percent_passing_2pct'] = np.nan
-
-    if ont_threshold_permissive is not None:
-        stats['percent_passing_5pct'] = 100 * (values <= ont_threshold_permissive).sum() / len(values)
-    else:
-        stats['percent_passing_5pct'] = np.nan
-
-    if ont_threshold_very_permissive is not None:
-        stats['percent_passing_10pct'] = 100 * (values <= ont_threshold_very_permissive).sum() / len(values)
-    else:
-        stats['percent_passing_10pct'] = np.nan
 
     return stats
 
-def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_rate, output_pdf):
-    """Create comprehensive visualizations of edit distance distributions."""
-    print(f"Creating visualizations in {output_pdf}...")
+# Visualization
+
+def plot_edit_distance_distributions(lf, segments, segment_lengths, ont_error_rate, output_pdf):
+    """Generate comprehensive visualizations of edit distance distributions."""
+    print(f"\nCreating visualizations in {output_pdf}...")
+
+    # For plotting, we need to collect the data (can't plot lazily)
+    # But we only collect the edit distance columns to minimize memory
+    edit_cols = [f"{seg}_edit_distance" for seg in segments]
+    # Filter "NMF" and cast to Int32
+    df_plot = lf.select([
+        pl.when(pl.col(col) != "NMF")
+        .then(pl.col(col).cast(pl.Float32, strict=False).round(0).cast(pl.Int32))
+        .otherwise(None)
+        .alias(col)
+        for col in edit_cols
+    ]).collect()
 
     with PdfPages(output_pdf) as pdf:
         # 1. Individual histograms for each segment
         for segment in segments:
-            edit_dist_col = f'{segment}_edit_distance'
-            if edit_dist_col not in df.columns:
+            edit_dist_col = f"{segment}_edit_distance"
+            if edit_dist_col not in df_plot.columns:
                 continue
 
-            values = df[edit_dist_col].dropna()
+            values = df_plot[edit_dist_col].drop_nulls().to_numpy()
             if len(values) == 0:
                 continue
 
             segment_length = segment_lengths.get(segment)
-            ont_threshold_2pct = calculate_ont_threshold(segment_length, 0.02)
-            ont_threshold_5pct = calculate_ont_threshold(segment_length, ont_error_rate)
-            ont_threshold_10pct = calculate_ont_threshold(segment_length, 0.10)
+            t2 = calculate_ont_threshold(segment_length, 0.02)
+            t5 = calculate_ont_threshold(segment_length, ont_error_rate)
+            t10 = calculate_ont_threshold(segment_length, 0.10)
 
             fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
 
             # Histogram
-            ax1.hist(values, bins=min(50, int(values.max()) + 1), edgecolor='black', alpha=0.7)
-            ax1.axvline(values.median(), color='red', linestyle='--',
-                       label=f'Median: {values.median():.1f}')
+            ax1.hist(values, bins=min(50, int(np.ceil(values.max())) + 1), edgecolor='black', alpha=0.7)
+            ax1.axvline(np.median(values), color='red', linestyle='--',
+                       label=f'Median: {np.median(values):.1f}')
 
-            if ont_threshold_2pct is not None:
-                ax1.axvline(ont_threshold_2pct, color='green', linestyle='--',
-                           linewidth=2, label=f'ONT 2% error: {ont_threshold_2pct}')
-            if ont_threshold_5pct is not None:
-                ax1.axvline(ont_threshold_5pct, color='orange', linestyle='--',
-                           linewidth=2, label=f'ONT {int(ont_error_rate*100)}% error: {ont_threshold_5pct}')
-            if ont_threshold_10pct is not None:
-                ax1.axvline(ont_threshold_10pct, color='purple', linestyle='--',
-                           linewidth=2, label=f'ONT 10% error: {ont_threshold_10pct}')
+            if t2 is not None:
+                ax1.axvline(t2, color='green', linestyle='--',
+                           linewidth=2, label=f'ONT 2% error: {t2}')
+            if t5 is not None:
+                ax1.axvline(t5, color='orange', linestyle='--',
+                           linewidth=2, label=f'ONT {int(ont_error_rate*100)}% error: {t5}')
+            if t10 is not None:
+                ax1.axvline(t10, color='purple', linestyle='--',
+                           linewidth=2, label=f'ONT 10% error: {t10}')
 
             ax1.set_xlabel('Edit Distance')
             ax1.set_ylabel('Frequency')
@@ -205,7 +536,7 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
             if segment_length:
                 title += f'\n(median length: {segment_length:.0f} bp)'
             ax1.set_title(title)
-            ax1.legend()
+            ax1.legend(loc='upper right')
             ax1.grid(True, alpha=0.3)
 
             # Cumulative distribution
@@ -213,33 +544,30 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
             cumulative = np.arange(1, len(sorted_vals) + 1) / len(sorted_vals)
             ax2.plot(sorted_vals, cumulative, linewidth=2)
 
-            if ont_threshold_2pct is not None:
-                pct_passing = 100 * (values <= ont_threshold_2pct).sum() / len(values)
-                ax2.axvline(ont_threshold_2pct, color='green', linestyle='--',
-                           linewidth=2, alpha=0.7,
-                           label=f'ONT 2% threshold: {ont_threshold_2pct} ({pct_passing:.1f}% pass)')
-            if ont_threshold_5pct is not None:
-                pct_passing = 100 * (values <= ont_threshold_5pct).sum() / len(values)
-                ax2.axvline(ont_threshold_5pct, color='orange', linestyle='--',
-                           linewidth=2, alpha=0.7,
-                           label=f'ONT {int(ont_error_rate*100)}% threshold: {ont_threshold_5pct} ({pct_passing:.1f}% pass)')
-            if ont_threshold_10pct is not None:
-                pct_passing = 100 * (values <= ont_threshold_10pct).sum() / len(values)
-                ax2.axvline(ont_threshold_10pct, color='purple', linestyle='--',
-                           linewidth=2, alpha=0.7,
-                           label=f'ONT 10% threshold: {ont_threshold_10pct} ({pct_passing:.1f}% pass)')
+            if t2 is not None:
+                pct_passing = 100 * (values <= t2).sum() / len(values)
+                ax2.axvline(t2, color='green', linestyle='--', linewidth=2, alpha=0.7,
+                           label=f'ONT 2%: {t2} ({pct_passing:.1f}% pass)')
+            if t5 is not None:
+                pct_passing = 100 * (values <= t5).sum() / len(values)
+                ax2.axvline(t5, color='orange', linestyle='--', linewidth=2, alpha=0.7,
+                           label=f'ONT {int(ont_error_rate*100)}%: {t5} ({pct_passing:.1f}% pass)')
+            if t10 is not None:
+                pct_passing = 100 * (values <= t10).sum() / len(values)
+                ax2.axvline(t10, color='purple', linestyle='--', linewidth=2, alpha=0.7,
+                           label=f'ONT 10%: {t10} ({pct_passing:.1f}% pass)')
 
             ax2.set_xlabel('Edit Distance')
             ax2.set_ylabel('Cumulative Fraction')
             ax2.set_title(f'{segment} Cumulative Distribution')
-            ax2.legend()
+            ax2.legend(loc='lower right')
             ax2.grid(True, alpha=0.3)
 
             plt.tight_layout()
             pdf.savefig()
             plt.close()
 
-        # 2. Comparison box plot (all segments)
+        # 2. Comparison box plot
         fig, ax = plt.subplots(figsize=(14, 6))
 
         plot_data = []
@@ -249,9 +577,9 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
         ont_thresholds_10pct = []
 
         for segment in segments:
-            edit_dist_col = f'{segment}_edit_distance'
-            if edit_dist_col in df.columns:
-                values = df[edit_dist_col].dropna()
+            edit_dist_col = f"{segment}_edit_distance"
+            if edit_dist_col in df_plot.columns:
+                values = df_plot[edit_dist_col].drop_nulls().to_numpy()
                 if len(values) > 0:
                     plot_data.append(values)
                     plot_labels.append(segment)
@@ -262,40 +590,36 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
                     ont_thresholds_10pct.append(calculate_ont_threshold(segment_length, 0.10))
 
         if plot_data:
-            bp = ax.boxplot(plot_data, labels=plot_labels, patch_artist=True,
-                           showfliers=False)  # Hide outliers for clarity
+            bp = ax.boxplot(plot_data, tick_labels=plot_labels, patch_artist=True, showfliers=False)
 
-            # Color barcode segments differently from fixed segments
+            # Color code
             for i, (patch, label) in enumerate(zip(bp['boxes'], plot_labels)):
                 if label in ['CBC', 'i7', 'i5']:
                     patch.set_facecolor('lightblue')
                 else:
                     patch.set_facecolor('lightcoral')
 
-            # Plot ONT thresholds as horizontal lines per segment
+            # Plot thresholds
             x_positions = range(1, len(plot_labels) + 1)
-            for i, (x, thr_2, thr_5, thr_10) in enumerate(zip(x_positions, ont_thresholds_2pct, ont_thresholds_5pct, ont_thresholds_10pct)):
-                if thr_2 is not None:
-                    ax.plot([x-0.3, x+0.3], [thr_2, thr_2], 'g-', linewidth=2, alpha=0.7)
-                if thr_5 is not None:
-                    ax.plot([x-0.3, x+0.3], [thr_5, thr_5], 'orange', linewidth=2, alpha=0.7)
-                if thr_10 is not None:
-                    ax.plot([x-0.3, x+0.3], [thr_10, thr_10], 'purple', linewidth=2, alpha=0.7)
+            for x, t2, t5, t10 in zip(x_positions, ont_thresholds_2pct, ont_thresholds_5pct, ont_thresholds_10pct):
+                if t2 is not None:
+                    ax.plot([x-0.3, x+0.3], [t2, t2], 'g-', linewidth=2, alpha=0.7)
+                if t5 is not None:
+                    ax.plot([x-0.3, x+0.3], [t5, t5], 'orange', linewidth=2, alpha=0.7)
+                if t10 is not None:
+                    ax.plot([x-0.3, x+0.3], [t10, t10], 'purple', linewidth=2, alpha=0.7)
 
             ax.set_ylabel('Edit Distance')
             ax.set_title('Edit Distance Comparison Across Segments')
             ax.tick_params(axis='x', rotation=45)
             ax.grid(True, alpha=0.3, axis='y')
 
-            # Add legend
-            from matplotlib.patches import Patch
-            from matplotlib.lines import Line2D
             legend_elements = [
                 Patch(facecolor='lightblue', label='Barcode segments'),
                 Patch(facecolor='lightcoral', label='Fixed segments'),
-                Line2D([0], [0], color='green', linewidth=2, label='ONT 2% error threshold'),
-                Line2D([0], [0], color='orange', linewidth=2, label=f'ONT {int(ont_error_rate*100)}% error threshold'),
-                Line2D([0], [0], color='purple', linewidth=2, label='ONT 10% error threshold')
+                Line2D([0], [0], color='green', linewidth=2, label='ONT 2% threshold'),
+                Line2D([0], [0], color='orange', linewidth=2, label=f'ONT {int(ont_error_rate*100)}% threshold'),
+                Line2D([0], [0], color='purple', linewidth=2, label='ONT 10% threshold')
             ]
             ax.legend(handles=legend_elements, loc='upper right')
 
@@ -303,29 +627,26 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
             pdf.savefig()
             plt.close()
 
-        # 3. Error rate distribution plot (edit distance / segment length)
+        # 3. Error rate distribution
         fig, ax = plt.subplots(figsize=(12, 6))
 
         error_rate_data = []
         error_rate_labels = []
 
         for segment in segments:
-            edit_dist_col = f'{segment}_edit_distance'
+            edit_dist_col = f"{segment}_edit_distance"
             segment_length = segment_lengths.get(segment)
 
-            if edit_dist_col in df.columns and segment_length and segment_length > 0:
-                values = df[edit_dist_col].dropna()
+            if edit_dist_col in df_plot.columns and segment_length and segment_length > 0:
+                values = df_plot[edit_dist_col].drop_nulls().to_numpy()
                 if len(values) > 0:
-                    # Calculate error rates as percentages
                     error_rates = (values / segment_length) * 100
                     error_rate_data.append(error_rates)
                     error_rate_labels.append(f'{segment}\n({segment_length:.0f}bp)')
 
         if error_rate_data:
-            bp = ax.boxplot(error_rate_data, labels=error_rate_labels, patch_artist=True,
-                           showfliers=False)
+            bp = ax.boxplot(error_rate_data, tick_labels=error_rate_labels, patch_artist=True, showfliers=False)
 
-            # Color barcode segments differently
             for i, (patch, label) in enumerate(zip(bp['boxes'], error_rate_labels)):
                 segment_name = label.split('\n')[0]
                 if segment_name in ['CBC', 'i7', 'i5']:
@@ -333,234 +654,1146 @@ def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_ra
                 else:
                     patch.set_facecolor('lightcoral')
 
-            # Add reference lines for 2%, 5%, and 10% error
             ax.axhline(2, color='green', linestyle='--', linewidth=2, alpha=0.7, label='2% error rate')
             ax.axhline(ont_error_rate * 100, color='orange', linestyle='--', linewidth=2, alpha=0.7,
                       label=f'{int(ont_error_rate*100)}% error rate')
             ax.axhline(10, color='purple', linestyle='--', linewidth=2, alpha=0.7, label='10% error rate')
 
             ax.set_ylabel('Error Rate (%)')
-            ax.set_title('Error Rate Distribution Across Segments\n(Edit Distance / Segment Length)')
+            ax.set_title('Error Rate Distribution Across Segments')
             ax.tick_params(axis='x', rotation=45)
             ax.grid(True, alpha=0.3, axis='y')
-            ax.legend()
+            ax.legend(loc='upper right')
 
             plt.tight_layout()
             pdf.savefig()
             plt.close()
 
-        # 4. Heatmap of correlation between segment edit distances
-        if len(segments) > 1:
-            edit_dist_df = df[[f'{seg}_edit_distance' for seg in segments
-                              if f'{seg}_edit_distance' in df.columns]].copy()
-            edit_dist_df.columns = [col.replace('_edit_distance', '') for col in edit_dist_df.columns]
-
-            if len(edit_dist_df.columns) > 1:
-                fig, ax = plt.subplots(figsize=(10, 8))
-                corr = edit_dist_df.corr()
-                sns.heatmap(corr, annot=True, fmt='.2f', cmap='coolwarm', center=0,
-                           square=True, ax=ax, cbar_kws={'label': 'Correlation'})
-                ax.set_title('Edit Distance Correlation Between Segments')
-                plt.tight_layout()
-                pdf.savefig()
-                plt.close()
+# Filtering recommendations
 
 def generate_filtering_recommendations(stats_df, ont_error_rate):
-    """Generate filtering threshold recommendations based on statistics."""
+    """Generate filtering code recommendations."""
     print("\n" + "="*80)
     print("FILTERING RECOMMENDATIONS")
     print("="*80)
 
-    recommendations = []
-
-    for _, row in stats_df.iterrows():
+    for row in stats_df.iter_rows(named=True):
         segment = row['segment']
-
-        # ONT-aware thresholds (preferred for ONT data)
-        ont_threshold_2pct = row['ont_threshold_2pct']
-        ont_threshold_5pct = row['ont_threshold_5pct']
-        ont_threshold_10pct = row['ont_threshold_10pct']
-
-        # Data-driven thresholds (95th and 99th percentiles)
-        p95_threshold = row['p95']
-        p99_threshold = row['p99']
-
-        # Strict threshold (only perfect or near-perfect matches)
-        strict_threshold = 1 if row['percent_ed1_or_less'] > 80 else 2
-
-        rec = {
-            'segment': segment,
-            'median_length': row['median_length'],
-            'ont_threshold_2pct': ont_threshold_2pct,
-            'ont_threshold_5pct': ont_threshold_5pct,
-            'ont_threshold_10pct': ont_threshold_10pct,
-            'percent_passing_2pct': row['percent_passing_2pct'],
-            'percent_passing_5pct': row['percent_passing_5pct'],
-            'percent_passing_10pct': row['percent_passing_10pct'],
-            'strict_threshold': strict_threshold,
-            'p95_threshold': p95_threshold,
-            'p99_threshold': p99_threshold,
-            'percent_perfect': row['percent_perfect'],
-        }
-
-        recommendations.append(rec)
-
         print(f"\n{segment} (median length: {row['median_length']:.0f} bp):")
-        print(f"  Perfect matches: {row['percent_perfect']:.1f}%")
-        print(f"  Median edit distance: {row['median']:.1f}")
-        print(f"\n  ONT-based thresholds (recommended for ONT data):")
-        if not np.isnan(ont_threshold_2pct):
-            print(f"    - Conservative (2% error):       edit_distance <= {ont_threshold_2pct} ({row['percent_passing_2pct']:.1f}% of reads)")
-        if not np.isnan(ont_threshold_5pct):
-            print(f"    - Permissive ({int(ont_error_rate*100)}% error):        edit_distance <= {ont_threshold_5pct} ({row['percent_passing_5pct']:.1f}% of reads)")
-        if not np.isnan(ont_threshold_10pct):
-            print(f"    - Very permissive (10% error):   edit_distance <= {ont_threshold_10pct} ({row['percent_passing_10pct']:.1f}% of reads)")
 
-        print(f"\n  Data-driven thresholds:")
-        print(f"    - Very strict (perfect only):       edit_distance <= {strict_threshold}")
-        print(f"    - 95th percentile:                  edit_distance <= {p95_threshold:.0f}")
-        print(f"    - 99th percentile:                  edit_distance <= {p99_threshold:.0f}")
+        # Handle cases where statistics might be None
+        if row['percent_perfect'] is not None:
+            print(f"  Perfect matches: {row['percent_perfect']:.1f}%")
+        else:
+            print(f"  Perfect matches: N/A (no segments detected)")
 
-    print("\n" + "="*80)
-    print("RECOMMENDED FILTERING CODE (ONT-aware)")
-    print("="*80)
-    print("\nimport pandas as pd")
-    print("df = pd.read_parquet('annotations_valid.parquet')")
+        if row['median'] is not None:
+            print(f"  Median edit distance: {row['median']:.1f}")
+        else:
+            print(f"  Median edit distance: N/A (no segments detected)")
 
-    print("\n# Conservative filtering (2% error rate - high quality)")
-    print("df_conservative = df[")
-    for rec in recommendations:
-        if not np.isnan(rec['ont_threshold_2pct']):
-            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_2pct']}) &")
-    print("].copy()")
+        print(f"\n  ONT-based thresholds:")
 
-    print("\n# Permissive filtering (5% error rate - balance quality/quantity)")
-    print("df_permissive = df[")
-    for rec in recommendations:
-        if not np.isnan(rec['ont_threshold_5pct']):
-            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_5pct']}) &")
-    print("].copy()")
-
-    print("\n# Very permissive filtering (10% error rate - maximum read retention)")
-    print("df_very_permissive = df[")
-    for rec in recommendations:
-        if not np.isnan(rec['ont_threshold_10pct']):
-            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_10pct']}) &")
-    print("].copy()")
-
-    print("\n# Data-driven filtering (95th percentile)")
-    print("df_p95 = df[")
-    for rec in recommendations:
-        print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['p95_threshold']:.0f}) &")
-    print("].copy()")
+        if row['ont_threshold_2pct'] is not None:
+            print(f"    - Conservative (2%):      <= {row['ont_threshold_2pct']} ({row['percent_passing_2pct']:.1f}% pass)")
+        if row['ont_threshold_5pct'] is not None:
+            print(f"    - Permissive ({int(ont_error_rate*100)}%):       <= {row['ont_threshold_5pct']} ({row['percent_passing_5pct']:.1f}% pass)")
+        if row['ont_threshold_10pct'] is not None:
+            print(f"    - Very permissive (10%):  <= {row['ont_threshold_10pct']} ({row['percent_passing_10pct']:.1f}% pass)")
 
     print("\n" + "="*80)
-    print("INTERPRETATION GUIDE")
+    print("RECOMMENDED FILTERING CODE")
     print("="*80)
-    print("""
-ONT-based thresholds account for segment length:
-  - Shorter segments (e.g., UMI ~12bp) tolerate fewer errors
-  - Longer segments (e.g., p5 ~25bp) can have more errors while staying under error %
-  - 2% error threshold: conservative, high-quality filtering
-  - 5% error threshold: permissive, within typical ONT specs (2-5% error rate)
-  - 10% error threshold: very permissive, for maximum read retention or lower quality runs
+    print("\nimport polars as pl")
+    print("lf = pl.scan_parquet('annotations_valid.parquet')")
 
-Data-driven thresholds (percentiles) show your actual data distribution:
-  - Compare ONT thresholds vs percentiles to see if data matches expectations
-  - If p95 >> ONT 5% threshold: data may have quality issues
-  - If p95 ≈ ONT 5% threshold: data quality matches ONT expectations
-  - If p95 << ONT 5% threshold: data quality is better than expected
-""")
+    # --- Conservative (2% error rate) ---
+    print("\n# Conservative (2% error rate)")
+    print("filtered_conservative = lf.filter(")
+    conservative_filters = []
+    for row in stats_df.iter_rows(named=True):
+        if row['ont_threshold_2pct'] is not None:
+            conservative_filters.append(f"    (pl.col('{row['segment']}_edit_distance') <= {row['ont_threshold_2pct']})")
+    print(" &\n".join(conservative_filters))
+    print(").collect()")
 
-    return pd.DataFrame(recommendations)
+    # --- Permissive (5% error rate) ---
+    print("\n# Permissive (5% error rate)")
+    print("filtered_permissive = lf.filter(")
+    permissive_filters = []
+    for row in stats_df.iter_rows(named=True):
+        if row['ont_threshold_5pct'] is not None:
+            permissive_filters.append(f"    (pl.col('{row['segment']}_edit_distance') <= {row['ont_threshold_5pct']})")
+    print(" &\n".join(permissive_filters))
+    print(").collect()")
+
+
+############################################################
+# Valid vs Invalid Comparison
+############################################################
+
+def analyze_invalid_by_reason(lf_invalid, segments, segment_lengths, ont_error_rate, max_reasons=20):
+    """
+    Analyze invalid reads broken down by failure reason.
+
+    Args:
+        lf_invalid: LazyFrame with invalid reads
+        segments: List of segment names
+        segment_lengths: Dictionary of segment lengths
+        ont_error_rate: ONT error rate threshold
+        max_reasons: Maximum number of top reasons to analyze (default: 20)
+
+    Returns DataFrame with statistics per reason category.
+    """
+    print("\nAnalyzing invalid reads by failure reason...")
+
+    # Get reason counts first to identify top N
+    reason_counts = (
+        lf_invalid.group_by("reason")
+        .agg(pl.len().alias("count"))
+        .sort("count", descending=True)
+        .collect()
+    )
+
+    total_unique = len(reason_counts)
+    print(f"  Found {total_unique:,} unique failure reasons")
+
+    # Limit to top N reasons
+    top_reasons_df = reason_counts.head(max_reasons)
+    top_reasons = top_reasons_df["reason"].to_list()
+    top_counts = dict(zip(top_reasons_df["reason"].to_list(), top_reasons_df["count"].to_list()))
+
+    print(f"  Analyzing top {len(top_reasons)} of {total_unique:,} failure reasons")
+
+    all_reason_stats = []
+
+    for reason in top_reasons:
+        # Filter to this reason
+        lf_reason = lf_invalid.filter(pl.col("reason") == reason)
+
+        # Get count from our pre-computed dictionary
+        count = top_counts[reason]
+
+        # Compute stats for each segment
+        for segment in segments:
+            stats = compute_segment_statistics(
+                lf_reason, segment, segment_lengths.get(segment), ont_error_rate
+            )
+            stats["reason"] = reason
+            stats["reason_count"] = count
+            all_reason_stats.append(stats)
+
+    return pl.DataFrame(all_reason_stats)
+
+
+def plot_valid_vs_invalid_comparison(lf_valid, lf_invalid, segments, segment_lengths, output_pdf):
+    """
+    Create violin plots comparing edit distance distributions between valid and invalid reads.
+    """
+    print(f"\nCreating valid vs invalid comparison plots in {output_pdf}...")
+
+    with PdfPages(output_pdf) as pdf:
+        for segment in segments:
+            edit_col = f"{segment}_edit_distance"
+            segment_length = segment_lengths.get(segment)
+
+            # Collect data for both datasets
+            valid_data = lf_valid.select([
+                pl.when(pl.col(edit_col) != "NMF")
+                .then(pl.col(edit_col).cast(pl.Float32, strict=False).round(0).cast(pl.Int32))
+                .otherwise(None)
+                .alias(edit_col)
+            ]).collect()
+
+            invalid_data = lf_invalid.select([
+                pl.when(pl.col(edit_col) != "NMF")
+                .then(pl.col(edit_col).cast(pl.Float32, strict=False).round(0).cast(pl.Int32))
+                .otherwise(None)
+                .alias(edit_col)
+            ]).collect()
+
+            valid_values = valid_data[edit_col].drop_nulls().to_numpy()
+            invalid_values = invalid_data[edit_col].drop_nulls().to_numpy()
+
+            if len(valid_values) == 0 and len(invalid_values) == 0:
+                continue
+
+            # Create comparison plot
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+            # Violin plot
+            plot_data = []
+            labels = []
+            if len(valid_values) > 0:
+                plot_data.append(valid_values)
+                labels.append('Valid')
+            if len(invalid_values) > 0:
+                plot_data.append(invalid_values)
+                labels.append('Invalid')
+
+            if plot_data:
+                parts = ax1.violinplot(plot_data, positions=range(len(plot_data)),
+                                      showmeans=True, showmedians=True)
+                ax1.set_xticks(range(len(labels)))
+                ax1.set_xticklabels(labels)
+                ax1.set_ylabel('Edit Distance')
+                title = f'{segment} - Valid vs Invalid'
+                if segment_length:
+                    title += f'\n(median length: {segment_length:.0f} bp)'
+                ax1.set_title(title)
+                ax1.grid(True, alpha=0.3, axis='y')
+
+                # Add sample sizes
+                for i, (data, label) in enumerate(zip(plot_data, labels)):
+                    ax1.text(i, ax1.get_ylim()[1]*0.95, f'n={len(data):,}',
+                            ha='center', va='top', fontsize=9)
+
+            # Cumulative distribution comparison
+            if len(valid_values) > 0:
+                sorted_valid = np.sort(valid_values)
+                cumulative_valid = np.arange(1, len(sorted_valid) + 1) / len(sorted_valid)
+                ax2.plot(sorted_valid, cumulative_valid, linewidth=2,
+                        label=f'Valid (n={len(valid_values):,})', color='blue')
+
+            if len(invalid_values) > 0:
+                sorted_invalid = np.sort(invalid_values)
+                cumulative_invalid = np.arange(1, len(sorted_invalid) + 1) / len(sorted_invalid)
+                ax2.plot(sorted_invalid, cumulative_invalid, linewidth=2,
+                        label=f'Invalid (n={len(invalid_values):,})', color='red', alpha=0.7)
+
+            ax2.set_xlabel('Edit Distance')
+            ax2.set_ylabel('Cumulative Fraction')
+            ax2.set_title(f'{segment} - Cumulative Distribution')
+            ax2.legend(loc='lower right')
+            ax2.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+
+def plot_invalid_reason_breakdown(reason_stats_df, segments, output_pdf):
+    """
+    Plot edit distance statistics broken down by invalid reason.
+    """
+    print(f"\nCreating invalid reason breakdown plots in {output_pdf}...")
+
+    with PdfPages(output_pdf) as pdf:
+        # Get top reasons by read count
+        reason_counts = (
+            reason_stats_df
+            .group_by("reason")
+            .agg(pl.col("reason_count").first())
+            .sort("reason_count", descending=True)
+        )
+
+        top_reasons = reason_counts["reason"].to_list()[:10]  # Top 10 reasons
+
+        for segment in segments:
+            seg_data = reason_stats_df.filter(pl.col("segment") == segment)
+
+            if len(seg_data) == 0:
+                continue
+
+            # Filter to top reasons
+            seg_data = seg_data.filter(pl.col("reason").is_in(top_reasons))
+
+            if len(seg_data) == 0:
+                continue
+
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+            # Mean edit distance by reason
+            reasons = seg_data["reason"].to_list()
+            means = seg_data["mean"].to_list()
+            counts = seg_data["reason_count"].to_list()
+
+            # Filter out None values and sort by mean edit distance
+            valid_data = [(r, m, c) for r, m, c in zip(reasons, means, counts) if m is not None]
+            sorted_data = sorted(valid_data, key=lambda x: x[1])
+            reasons_sorted, means_sorted, counts_sorted = zip(*sorted_data) if sorted_data else ([], [], [])
+
+            if reasons_sorted:
+                y_pos = np.arange(len(reasons_sorted))
+                bars = ax1.barh(y_pos, means_sorted, color='skyblue', edgecolor='black')
+                ax1.set_yticks(y_pos)
+                ax1.set_yticklabels([f"{r[:40]}..." if len(r) > 40 else r for r in reasons_sorted],
+                                   fontsize=8)
+                ax1.set_xlabel('Mean Edit Distance')
+                ax1.set_title(f'{segment} - Mean Edit Distance by Failure Reason')
+                ax1.grid(True, alpha=0.3, axis='x')
+
+                # Add read counts as text
+                for i, (bar, count) in enumerate(zip(bars, counts_sorted)):
+                    width = bar.get_width()
+                    ax1.text(width, bar.get_y() + bar.get_height()/2,
+                            f' n={count:,}', va='center', fontsize=7)
+
+            # Perfect match rate by reason
+            perfect_pcts = seg_data["percent_perfect"].to_list()
+            # Filter out None values and sort by perfect match rate (descending)
+            valid_data2 = [(r, p, c) for r, p, c in zip(reasons, perfect_pcts, counts) if p is not None]
+            sorted_data2 = sorted(valid_data2, key=lambda x: x[1], reverse=True)
+            reasons_sorted2, perfect_sorted, counts_sorted2 = zip(*sorted_data2) if sorted_data2 else ([], [], [])
+
+            if reasons_sorted2:
+                y_pos = np.arange(len(reasons_sorted2))
+                bars = ax2.barh(y_pos, perfect_sorted, color='lightgreen', edgecolor='black')
+                ax2.set_yticks(y_pos)
+                ax2.set_yticklabels([f"{r[:40]}..." if len(r) > 40 else r for r in reasons_sorted2],
+                                   fontsize=8)
+                ax2.set_xlabel('Perfect Match Rate (%)')
+                ax2.set_title(f'{segment} - Perfect Matches by Failure Reason')
+                ax2.grid(True, alpha=0.3, axis='x')
+
+                # Add read counts
+                for i, (bar, count) in enumerate(zip(bars, counts_sorted2)):
+                    width = bar.get_width()
+                    ax2.text(width, bar.get_y() + bar.get_height()/2,
+                            f' n={count:,}', va='center', fontsize=7)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+
+def compare_detection_rates(stats_valid, stats_invalid):
+    """
+    Compare segment detection rates (NMF rates) between valid and invalid reads.
+    """
+    print("\n" + "="*80)
+    print("SEGMENT DETECTION RATE COMPARISON")
+    print("="*80)
+
+    comparison = []
+
+    for seg_valid in stats_valid:
+        segment = seg_valid['segment']
+
+        # Find matching invalid segment
+        seg_invalid = next((s for s in stats_invalid if s['segment'] == segment), None)
+
+        if seg_invalid:
+            comparison.append({
+                'segment': segment,
+                'valid_nmf_pct': seg_valid['percent_nmf'],
+                'invalid_nmf_pct': seg_invalid['percent_nmf'],
+                'nmf_diff': seg_invalid['percent_nmf'] - seg_valid['percent_nmf'],
+                'valid_mean_ed': seg_valid['mean'],
+                'invalid_mean_ed': seg_invalid['mean'],
+                'ed_diff': (seg_invalid['mean'] - seg_valid['mean']) if seg_invalid['mean'] and seg_valid['mean'] else None
+            })
+
+    comp_df = pl.DataFrame(comparison)
+    print(comp_df)
+
+    return comp_df
+
+
+############################################################
+# Quality Score Analysis
+############################################################
+
+def plot_score_distributions(lf, segments, output_pdf):
+    """
+    Plot quality score distributions for each segment and overall read quality.
+    """
+    print(f"\nCreating quality score distribution plots in {output_pdf}...")
+
+    # Collect score columns
+    score_cols = [f"{seg}_score" for seg in segments] + ["read_quality_score"]
+    existing_cols = [c for c in score_cols if c in lf.collect_schema()]
+
+    if not existing_cols:
+        print("  No score columns found - skipping score visualization")
+        return
+
+    df_scores = lf.select(existing_cols).collect()
+
+    with PdfPages(output_pdf) as pdf:
+        # 1. Individual segment score distributions
+        for seg in segments:
+            score_col = f"{seg}_score"
+            if score_col not in df_scores.columns:
+                continue
+
+            scores = df_scores[score_col].drop_nulls().to_numpy()
+            if len(scores) == 0:
+                continue
+
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+            # Histogram
+            ax1.hist(scores, bins=50, edgecolor='black', alpha=0.7, color='skyblue')
+            ax1.axvline(np.median(scores), color='red', linestyle='--',
+                       linewidth=2, label=f'Median: {np.median(scores):.3f}')
+            ax1.axvline(np.mean(scores), color='orange', linestyle='--',
+                       linewidth=2, label=f'Mean: {np.mean(scores):.3f}')
+            ax1.set_xlabel('Quality Score (1.0 = perfect)')
+            ax1.set_ylabel('Frequency')
+            ax1.set_title(f'{seg} - Quality Score Distribution\n(n={len(scores):,} non-concatenated reads)')
+            ax1.legend(loc='upper left')
+            ax1.grid(True, alpha=0.3)
+
+            # Cumulative distribution
+            sorted_scores = np.sort(scores)
+            cumulative = np.arange(1, len(sorted_scores) + 1) / len(sorted_scores)
+            ax2.plot(sorted_scores, cumulative, linewidth=2, color='skyblue')
+            ax2.axvline(np.median(scores), color='red', linestyle='--',
+                       linewidth=2, alpha=0.7, label=f'Median: {np.median(scores):.3f}')
+            ax2.axhline(0.95, color='green', linestyle='--', linewidth=1, alpha=0.5,
+                       label='95th percentile')
+            ax2.set_xlabel('Quality Score')
+            ax2.set_ylabel('Cumulative Fraction')
+            ax2.set_title(f'{seg} - Cumulative Score Distribution')
+            ax2.legend(loc='lower right')
+            ax2.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+        # 2. Overall read quality score
+        if "read_quality_score" in df_scores.columns:
+            read_scores = df_scores["read_quality_score"].drop_nulls().to_numpy()
+
+            if len(read_scores) > 0:
+                fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+                # Histogram
+                ax1.hist(read_scores, bins=50, edgecolor='black', alpha=0.7, color='coral')
+                ax1.axvline(np.median(read_scores), color='red', linestyle='--',
+                           linewidth=2, label=f'Median: {np.median(read_scores):.3f}')
+                ax1.axvline(np.mean(read_scores), color='orange', linestyle='--',
+                           linewidth=2, label=f'Mean: {np.mean(read_scores):.3f}')
+                ax1.set_xlabel('Read Quality Score (1.0 = perfect)')
+                ax1.set_ylabel('Frequency')
+                ax1.set_title(f'Overall Read Quality Distribution\n(n={len(read_scores):,} reads)')
+                ax1.legend(loc='upper left')
+                ax1.grid(True, alpha=0.3)
+
+                # Cumulative distribution
+                sorted_scores = np.sort(read_scores)
+                cumulative = np.arange(1, len(sorted_scores) + 1) / len(sorted_scores)
+                ax2.plot(sorted_scores, cumulative, linewidth=2, color='coral')
+                ax2.axvline(np.median(read_scores), color='red', linestyle='--',
+                           linewidth=2, alpha=0.7, label=f'Median: {np.median(read_scores):.3f}')
+                ax2.axhline(0.95, color='green', linestyle='--', linewidth=1, alpha=0.5,
+                           label='95th percentile')
+                ax2.set_xlabel('Read Quality Score')
+                ax2.set_ylabel('Cumulative Fraction')
+                ax2.set_title('Cumulative Read Quality Distribution')
+                ax2.legend(loc='lower right')
+                ax2.grid(True, alpha=0.3)
+
+                plt.tight_layout()
+                pdf.savefig()
+                plt.close()
+
+
+def plot_score_comparison(lf_valid, lf_invalid, segments, output_pdf):
+    """
+    Compare quality score distributions between valid and invalid reads.
+    """
+    print(f"\nCreating score comparison plots in {output_pdf}...")
+
+    with PdfPages(output_pdf) as pdf:
+        # 1. Compare overall read quality scores
+        if "read_quality_score" in lf_valid.collect_schema():
+            valid_scores = lf_valid.select("read_quality_score").collect()["read_quality_score"].drop_nulls().to_numpy()
+            invalid_scores = lf_invalid.select("read_quality_score").collect()["read_quality_score"].drop_nulls().to_numpy()
+
+            if len(valid_scores) > 0 or len(invalid_scores) > 0:
+                fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+                # Violin plot
+                plot_data = []
+                labels = []
+                if len(valid_scores) > 0:
+                    plot_data.append(valid_scores)
+                    labels.append('Valid')
+                if len(invalid_scores) > 0:
+                    plot_data.append(invalid_scores)
+                    labels.append('Invalid')
+
+                if plot_data:
+                    parts = ax1.violinplot(plot_data, positions=range(len(plot_data)),
+                                          showmeans=True, showmedians=True)
+                    ax1.set_xticks(range(len(labels)))
+                    ax1.set_xticklabels(labels)
+                    ax1.set_ylabel('Read Quality Score')
+                    ax1.set_title('Read Quality Score - Valid vs Invalid')
+                    ax1.grid(True, alpha=0.3, axis='y')
+
+                    # Add sample sizes and medians
+                    for i, (data, label) in enumerate(zip(plot_data, labels)):
+                        ax1.text(i, ax1.get_ylim()[1]*0.95,
+                                f'n={len(data):,}\nmedian={np.median(data):.3f}',
+                                ha='center', va='top', fontsize=9)
+
+                # Cumulative distributions
+                if len(valid_scores) > 0:
+                    sorted_valid = np.sort(valid_scores)
+                    cumulative_valid = np.arange(1, len(sorted_valid) + 1) / len(sorted_valid)
+                    ax2.plot(sorted_valid, cumulative_valid, linewidth=2,
+                            label=f'Valid (n={len(valid_scores):,})', color='blue')
+
+                if len(invalid_scores) > 0:
+                    sorted_invalid = np.sort(invalid_scores)
+                    cumulative_invalid = np.arange(1, len(sorted_invalid) + 1) / len(sorted_invalid)
+                    ax2.plot(sorted_invalid, cumulative_invalid, linewidth=2,
+                            label=f'Invalid (n={len(invalid_scores):,})', color='red', alpha=0.7)
+
+                ax2.set_xlabel('Read Quality Score')
+                ax2.set_ylabel('Cumulative Fraction')
+                ax2.set_title('Cumulative Score Distribution')
+                ax2.legend(loc='lower right')
+                ax2.grid(True, alpha=0.3)
+
+                plt.tight_layout()
+                pdf.savefig()
+                plt.close()
+
+        # 2. Per-segment score comparisons
+        for seg in segments:
+            score_col = f"{seg}_score"
+
+            if score_col not in lf_valid.collect_schema():
+                continue
+
+            valid_seg_scores = lf_valid.select(score_col).collect()[score_col].drop_nulls().to_numpy()
+            invalid_seg_scores = lf_invalid.select(score_col).collect()[score_col].drop_nulls().to_numpy()
+
+            if len(valid_seg_scores) == 0 and len(invalid_seg_scores) == 0:
+                continue
+
+            fig, ax = plt.subplots(figsize=(10, 6))
+
+            # Cumulative distributions
+            if len(valid_seg_scores) > 0:
+                sorted_valid = np.sort(valid_seg_scores)
+                cumulative_valid = np.arange(1, len(sorted_valid) + 1) / len(sorted_valid)
+                ax.plot(sorted_valid, cumulative_valid, linewidth=2,
+                       label=f'Valid (n={len(valid_seg_scores):,}, median={np.median(valid_seg_scores):.3f})',
+                       color='blue')
+
+            if len(invalid_seg_scores) > 0:
+                sorted_invalid = np.sort(invalid_seg_scores)
+                cumulative_invalid = np.arange(1, len(sorted_invalid) + 1) / len(sorted_invalid)
+                ax.plot(sorted_invalid, cumulative_invalid, linewidth=2,
+                       label=f'Invalid (n={len(invalid_seg_scores):,}, median={np.median(invalid_seg_scores):.3f})',
+                       color='red', alpha=0.7)
+
+            ax.set_xlabel(f'{seg} Quality Score')
+            ax.set_ylabel('Cumulative Fraction')
+            ax.set_title(f'{seg} - Score Comparison (Valid vs Invalid)')
+            ax.legend(loc='lower right')
+            ax.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+
+def export_ranked_reads(lf, output_file, n_top=1000, n_bottom=1000):
+    """
+    Export top and bottom ranked reads by quality score.
+
+    Args:
+        lf: LazyFrame with read_quality_score column
+        output_file: Path to output TSV file
+        n_top: Number of top-scoring reads to export
+        n_bottom: Number of bottom-scoring reads to export
+    """
+    print(f"\nExporting ranked reads to {output_file}...")
+
+    if "read_quality_score" not in lf.collect_schema():
+        print("  No read_quality_score column found - skipping ranked export")
+        return
+
+    # Get top and bottom reads
+    top_reads = (
+        lf.filter(pl.col("read_quality_score").is_not_null())
+        .sort("read_quality_score", descending=True)
+        .head(n_top)
+        .collect()
+    )
+
+    bottom_reads = (
+        lf.filter(pl.col("read_quality_score").is_not_null())
+        .sort("read_quality_score", descending=False)
+        .head(n_bottom)
+        .collect()
+    )
+
+    # Add rank column
+    top_reads = top_reads.with_columns([
+        pl.lit("top").alias("rank_category"),
+        (pl.arange(1, len(top_reads) + 1)).alias("rank")
+    ])
+
+    bottom_reads = bottom_reads.with_columns([
+        pl.lit("bottom").alias("rank_category"),
+        (pl.arange(1, len(bottom_reads) + 1)).alias("rank")
+    ])
+
+    # Combine
+    ranked_reads = pl.concat([top_reads, bottom_reads])
+
+    # Save
+    ranked_reads.write_csv(output_file, separator="\t")
+    print(f"  Exported {len(top_reads):,} top reads and {len(bottom_reads):,} bottom reads")
+
+
+############################################################
+# Anomalous Read Detection and Export
+############################################################
+
+def export_anomalous_reads(lf, anomaly_thresholds, output_file):
+    """
+    Export reads with anomalously short segments to TSV file.
+
+    Args:
+        lf: LazyFrame with segment length columns
+        anomaly_thresholds: Dictionary of minimum expected lengths per segment
+        output_file: Path to output TSV file
+    """
+    if not anomaly_thresholds:
+        print("  No anomaly thresholds specified - skipping anomalous read export")
+        return
+
+    print(f"\nExporting reads with anomalous segment lengths to {output_file}...")
+
+    # Build filter conditions for any segment below threshold
+    conditions = []
+    for seg, min_length in anomaly_thresholds.items():
+        length_col = f"{seg}_length"
+        if length_col in lf.collect_schema():
+            # Cast to Int64 to ensure numeric comparison
+            conditions.append(
+                (pl.col(length_col).cast(pl.Int64, strict=False).is_not_null()) &
+                (pl.col(length_col).cast(pl.Int64, strict=False) < min_length)
+            )
+
+    if not conditions:
+        print("  No matching segment columns found")
+        return
+
+    # Combine conditions with OR (anomalous in ANY segment)
+    combined_filter = conditions[0]
+    for condition in conditions[1:]:
+        combined_filter = combined_filter | condition
+
+    # Filter and collect
+    anomalous_reads = lf.filter(combined_filter).collect()
+
+    if len(anomalous_reads) == 0:
+        print("  No anomalous reads found")
+        return
+
+    # Save
+    anomalous_reads.write_csv(output_file, separator="\t")
+    print(f"  Exported {len(anomalous_reads):,} reads with anomalous segment lengths")
+
+    # Print breakdown by segment
+    for seg, min_length in anomaly_thresholds.items():
+        length_col = f"{seg}_length"
+        if length_col in anomalous_reads.columns:
+            count = len(anomalous_reads.filter(
+                (pl.col(length_col).cast(pl.Int64, strict=False).is_not_null()) &
+                (pl.col(length_col).cast(pl.Int64, strict=False) < min_length)
+            ))
+            if count > 0:
+                print(f"    {seg} <{min_length}bp: {count:,} reads")
+
+
+def print_anomaly_summary(length_stats_df):
+    """
+    Print summary of anomalous segment lengths.
+    """
+    # Filter to segments with anomaly detection enabled
+    anomalous_segments = length_stats_df.filter(
+        pl.col("min_expected_length").is_not_null()
+    )
+
+    if len(anomalous_segments) == 0:
+        return
+
+    print("\n" + "="*80)
+    print("SEGMENT LENGTH ANOMALY DETECTION")
+    print("="*80)
+    print(f"{'Segment':<15} {'Min Expected':<15} {'Anomalous Reads':<20} {'Percentage':<15} {'Min Observed':<15}")
+    print("-"*80)
+
+    for row in anomalous_segments.iter_rows(named=True):
+        segment = row['segment']
+        min_exp = row['min_expected_length']
+        anom_count = row['anomaly_count']
+        anom_pct = row['anomaly_percent']
+        min_obs = row['min_length']
+
+        print(f"{segment:<15} {min_exp:<15.0f} {anom_count:<20,} {anom_pct:<14.2f}% {min_obs:<15.0f}")
+
+    print("\nInterpretation:")
+    print("  - 'Min Expected' is the threshold below which segments are considered anomalous")
+    print("  - 'Anomalous Reads' are reads with segment lengths below the threshold")
+    print("  - 'Min Observed' shows the actual minimum length found in the data")
+    print("  - High anomaly percentages in 'valid' reads may indicate model errors")
+
+
+############################################################
+# Segment Length Distribution Analysis
+############################################################
+
+def plot_segment_length_distributions(lf, segments, median_lengths, output_pdf):
+    """
+    Plot segment length distributions with outlier boundaries.
+    """
+    print(f"\nCreating segment length distribution plots in {output_pdf}...")
+
+    # Collect length columns
+    length_cols = [f"{seg}_length" for seg in segments]
+    existing_cols = [c for c in length_cols if c in lf.collect_schema()]
+
+    if not existing_cols:
+        print("  No length columns found - skipping length visualization")
+        return
+
+    df_lengths = lf.select(existing_cols).collect()
+
+    with PdfPages(output_pdf) as pdf:
+        for seg in segments:
+            length_col = f"{seg}_length"
+            if length_col not in df_lengths.columns:
+                continue
+
+            lengths = df_lengths[length_col].drop_nulls().to_numpy()
+            if len(lengths) == 0:
+                continue
+
+            median_len = median_lengths.get(seg)
+            std_len = np.std(lengths)
+
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+            # Histogram
+            ax1.hist(lengths, bins=50, edgecolor='black', alpha=0.7, color='steelblue')
+            ax1.axvline(np.median(lengths), color='red', linestyle='--',
+                       linewidth=2, label=f'Median: {np.median(lengths):.1f}bp')
+            ax1.axvline(np.mean(lengths), color='orange', linestyle='--',
+                       linewidth=2, label=f'Mean: {np.mean(lengths):.1f}bp')
+
+            # Outlier boundaries (±2 std)
+            if median_len and std_len:
+                lower_bound = median_len - 2 * std_len
+                upper_bound = median_len + 2 * std_len
+                ax1.axvline(lower_bound, color='purple', linestyle=':', linewidth=2,
+                           alpha=0.7, label=f'±2σ bounds')
+                ax1.axvline(upper_bound, color='purple', linestyle=':', linewidth=2, alpha=0.7)
+
+            ax1.set_xlabel('Segment Length (bp)')
+            ax1.set_ylabel('Frequency')
+            ax1.set_title(f'{seg} - Length Distribution\n(n={len(lengths):,} non-concatenated reads)')
+            ax1.legend(loc='upper right')
+            ax1.grid(True, alpha=0.3)
+
+            # Cumulative distribution
+            sorted_lengths = np.sort(lengths)
+            cumulative = np.arange(1, len(sorted_lengths) + 1) / len(sorted_lengths)
+            ax2.plot(sorted_lengths, cumulative, linewidth=2, color='steelblue')
+            ax2.axvline(np.median(lengths), color='red', linestyle='--',
+                       linewidth=2, alpha=0.7, label=f'Median: {np.median(lengths):.1f}bp')
+            ax2.axhline(0.95, color='green', linestyle='--', linewidth=1, alpha=0.5,
+                       label='95th percentile')
+
+            ax2.set_xlabel('Segment Length (bp)')
+            ax2.set_ylabel('Cumulative Fraction')
+            ax2.set_title(f'{seg} - Cumulative Length Distribution')
+            ax2.legend(loc='lower right')
+            ax2.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+
+def plot_length_comparison(lf_valid, lf_invalid, segments, output_pdf):
+    """
+    Compare segment length distributions between valid and invalid reads.
+    """
+    print(f"\nCreating length comparison plots in {output_pdf}...")
+
+    with PdfPages(output_pdf) as pdf:
+        for seg in segments:
+            length_col = f"{seg}_length"
+
+            if length_col not in lf_valid.collect_schema():
+                continue
+
+            valid_lengths = lf_valid.select(length_col).collect()[length_col].drop_nulls().to_numpy()
+            invalid_lengths = lf_invalid.select(length_col).collect()[length_col].drop_nulls().to_numpy()
+
+            if len(valid_lengths) == 0 and len(invalid_lengths) == 0:
+                continue
+
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+            # Violin plot
+            plot_data = []
+            labels = []
+            if len(valid_lengths) > 0:
+                plot_data.append(valid_lengths)
+                labels.append('Valid')
+            if len(invalid_lengths) > 0:
+                plot_data.append(invalid_lengths)
+                labels.append('Invalid')
+
+            if plot_data:
+                parts = ax1.violinplot(plot_data, positions=range(len(plot_data)),
+                                      showmeans=True, showmedians=True)
+                ax1.set_xticks(range(len(labels)))
+                ax1.set_xticklabels(labels)
+                ax1.set_ylabel('Segment Length (bp)')
+                ax1.set_title(f'{seg} - Length Distribution (Valid vs Invalid)')
+                ax1.grid(True, alpha=0.3, axis='y')
+
+                # Add sample sizes and medians
+                for i, (data, label) in enumerate(zip(plot_data, labels)):
+                    ax1.text(i, ax1.get_ylim()[1]*0.95,
+                            f'n={len(data):,}\nmedian={np.median(data):.1f}bp',
+                            ha='center', va='top', fontsize=9)
+
+            # Cumulative distributions
+            if len(valid_lengths) > 0:
+                sorted_valid = np.sort(valid_lengths)
+                cumulative_valid = np.arange(1, len(sorted_valid) + 1) / len(sorted_valid)
+                ax2.plot(sorted_valid, cumulative_valid, linewidth=2,
+                        label=f'Valid (n={len(valid_lengths):,}, median={np.median(valid_lengths):.1f}bp)',
+                        color='blue')
+
+            if len(invalid_lengths) > 0:
+                sorted_invalid = np.sort(invalid_lengths)
+                cumulative_invalid = np.arange(1, len(sorted_invalid) + 1) / len(sorted_invalid)
+                ax2.plot(sorted_invalid, cumulative_invalid, linewidth=2,
+                        label=f'Invalid (n={len(invalid_lengths):,}, median={np.median(invalid_lengths):.1f}bp)',
+                        color='red', alpha=0.7)
+
+            ax2.set_xlabel('Segment Length (bp)')
+            ax2.set_ylabel('Cumulative Fraction')
+            ax2.set_title(f'{seg} - Cumulative Length Distribution')
+            ax2.legend(loc='lower right')
+            ax2.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+
+############################################################
+# Main
+############################################################
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Analyze edit distance distributions in annotated reads with ONT-specific thresholds'
+        description="Polars-based edit distance analysis (streaming, fast)"
     )
-    parser.add_argument('parquet_file', help='Path to annotations parquet file')
-    parser.add_argument('--output_dir', '-o',
-                       help='Output directory for results (default: same as input file)',
-                       default=None)
-    parser.add_argument('--ont_error_rate', '-e', type=float, default=0.05,
-                       help='Expected ONT error rate (default: 0.05 = 5%%)')
+    parser.add_argument("parquet_file", help="Path to valid annotations parquet file")
+    parser.add_argument("--invalid_parquet", "-i", help="Path to invalid annotations parquet file (optional)")
+    parser.add_argument("--output_dir", "-o", help="Output directory", default=None)
+    parser.add_argument("--ont_error_rate", "-e", type=float, default=0.05,
+                       help="Expected ONT error rate (default: 0.05)")
+    parser.add_argument("--sample_size", type=int, default=10_000,
+                       help="Sample size for length estimation (default: 10000)")
+    parser.add_argument("--analyze_reasons", action="store_true", default=False,
+                       help="Analyze invalid reads by failure reason (can be slow with many unique reasons)")
+    parser.add_argument("--max_reasons", type=int, default=20,
+                       help="Maximum number of top failure reasons to analyze (default: 20)")
+
+    # Anomaly detection arguments
+    parser.add_argument("--min_cdna_length", type=int, default=None,
+                       help="Minimum expected cDNA length in bp (default: None, no anomaly detection)")
+    parser.add_argument("--min_polya_length", type=int, default=None,
+                       help="Minimum expected polyA length in bp (default: None, no anomaly detection)")
+    parser.add_argument("--min_umi_length", type=int, default=None,
+                       help="Minimum expected UMI length in bp (default: None, no anomaly detection)")
+    parser.add_argument("--min_cbc_length", type=int, default=None,
+                       help="Minimum expected CBC length in bp (default: None, no anomaly detection)")
 
     args = parser.parse_args()
 
-    # Set output directory
+    # Build anomaly thresholds dictionary from command-line args
+    anomaly_thresholds = {}
+    if args.min_cdna_length is not None:
+        anomaly_thresholds['cDNA'] = args.min_cdna_length
+    if args.min_polya_length is not None:
+        anomaly_thresholds['polyA'] = args.min_polya_length
+    if args.min_umi_length is not None:
+        anomaly_thresholds['UMI'] = args.min_umi_length
+    if args.min_cbc_length is not None:
+        anomaly_thresholds['CBC'] = args.min_cbc_length
+
+    # Output directory
     if args.output_dir:
         output_dir = Path(args.output_dir)
     else:
         output_dir = Path(args.parquet_file).parent
-
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load data
-    df = load_valid_reads(args.parquet_file)
+    # Print anomaly detection configuration
+    if anomaly_thresholds:
+        print("\nAnomaly Detection Thresholds:")
+        for seg, min_len in anomaly_thresholds.items():
+            print(f"  {seg}: minimum {min_len}bp")
+    else:
+        print("\nNo anomaly detection thresholds specified (use --min_cdna_length, --min_polya_length, etc.)")
 
-    # Identify edit distance columns
-    edit_dist_cols, barcode_segments, fixed_segments = identify_edit_distance_columns(df)
+    # Load data lazily
+    print(f"Scanning {args.parquet_file}...")
+    lf = pl.scan_parquet(args.parquet_file)
+
+    # Identify segments
+    schema = lf.collect_schema()
+    edit_dist_cols, barcode_segments, fixed_segments = identify_edit_distance_columns(schema)
     all_segments = barcode_segments + fixed_segments
 
     if not edit_dist_cols:
-        print("ERROR: No edit distance columns found in the parquet file!")
-        print("Available columns:", df.columns.tolist())
+        print("ERROR: No edit distance columns found!")
+        print("Available columns:", list(schema.keys()))
         sys.exit(1)
 
-    print(f"\nFound edit distance columns for {len(all_segments)} segments:")
+    print(f"\nFound {len(all_segments)} segments:")
     print(f"  Barcode segments: {', '.join(barcode_segments)}")
     print(f"  Fixed segments: {', '.join(fixed_segments)}")
 
-    # Calculate segment lengths
+    # Estimate segment lengths
     print("\nCalculating median segment lengths...")
-    segment_lengths = get_segment_lengths(df, all_segments)
+    segment_lengths = compute_segment_lengths(lf, all_segments, args.sample_size)
     for segment, length in segment_lengths.items():
-        print(f"  {segment}: {length:.0f} bp")
+        if length is not None:
+            print(f"  {segment}: {length:.0f} bp")
 
-    # Calculate statistics for each segment
+    # Add segment length columns for distribution analysis
+    print("\nAdding segment length columns...")
+    lf = add_segment_length_columns(lf, all_segments)
+
+    # Add quality scores (inverted normalized edit distances)
+    print("\nComputing quality scores (excluding concatenated reads)...")
+    lf = add_segment_scores(lf, all_segments, segment_lengths)
+
+    # Compute segment length statistics
+    length_stats_df = compute_segment_length_statistics(lf, all_segments, segment_lengths, anomaly_thresholds)
+
+    # Compute statistics per segment
     print(f"\nCalculating statistics (ONT error rate: {args.ont_error_rate*100:.0f}%)...")
-    stats_list = []
-    for segment in all_segments:
-        edit_dist_col = f'{segment}_edit_distance'
-        segment_length = segment_lengths.get(segment)
-        stats = calculate_statistics(df, segment, edit_dist_col,
-                                     segment_length=segment_length,
-                                     ont_error_rate=args.ont_error_rate)
-        if stats:
-            stats_list.append(stats)
+    all_stats = []
+    for seg in all_segments:
+        print(f"  Processing {seg}...")
+        stats = compute_segment_statistics(
+            lf, seg, segment_lengths.get(seg), args.ont_error_rate
+        )
+        all_stats.append(stats)
 
-    stats_df = pd.DataFrame(stats_list)
+    # Create stats DataFrame
+    stats_df = pl.DataFrame(all_stats)
 
-    # Save statistics to TSV
-    stats_file = output_dir / 'edit_distance_statistics.tsv'
-    stats_df.to_csv(stats_file, sep='\t', index=False, float_format='%.2f')
+    # Save statistics
+    stats_file = output_dir / "edit_distance_statistics.tsv"
+    stats_df.write_csv(stats_file, separator="\t")
     print(f"\nSaved statistics to {stats_file}")
 
-    # Print summary table
+    # Print summary
     print("\n" + "="*80)
     print("SUMMARY STATISTICS")
     print("="*80)
-    display_cols = ['segment', 'median_length', 'reads_with_segment', 'percent_perfect',
-                    'median', 'ont_threshold_2pct', 'percent_passing_2pct',
-                    'ont_threshold_5pct', 'percent_passing_5pct',
-                    'ont_threshold_10pct', 'percent_passing_10pct']
-    print(stats_df[display_cols].to_string(index=False))
+    display_cols = [
+        'segment', 'median_length', 'reads_with_segment', 'nmf_count', 'percent_nmf',
+        'percent_perfect', 'median', 'ont_threshold_2pct', 'percent_passing_2pct',
+        'ont_threshold_5pct', 'percent_passing_5pct',
+        'ont_threshold_10pct', 'percent_passing_10pct'
+    ]
+    print(stats_df.select(display_cols))
 
-    # Create visualizations
-    plot_file = output_dir / 'edit_distance_distributions.pdf'
-    plot_edit_distance_distributions(df, all_segments, segment_lengths,
-                                     args.ont_error_rate, plot_file)
+    # Generate visualizations
+    plot_file = output_dir / "edit_distance_distributions.pdf"
+    plot_edit_distance_distributions(lf, all_segments, segment_lengths, args.ont_error_rate, plot_file)
     print(f"\nSaved visualizations to {plot_file}")
 
-    # Generate filtering recommendations
-    recommendations_df = generate_filtering_recommendations(stats_df, args.ont_error_rate)
-    rec_file = output_dir / 'filtering_recommendations.tsv'
-    recommendations_df.to_csv(rec_file, sep='\t', index=False, float_format='%.1f')
-    print(f"\nSaved recommendations to {rec_file}")
+    # Generate recommendations
+    generate_filtering_recommendations(stats_df, args.ont_error_rate)
+
+    # Generate quality score visualizations
+    score_plot_file = output_dir / "quality_score_distributions.pdf"
+    plot_score_distributions(lf, all_segments, score_plot_file)
+    print(f"\nSaved quality score plots to {score_plot_file}")
+
+    # Export ranked reads
+    ranked_file = output_dir / "ranked_reads.tsv"
+    export_ranked_reads(lf, ranked_file, n_top=1000, n_bottom=1000)
+
+    # Save segment length statistics
+    length_stats_file = output_dir / "segment_length_statistics.tsv"
+    length_stats_df.write_csv(length_stats_file, separator="\t")
+    print(f"\nSaved segment length statistics to {length_stats_file}")
+
+    # Print length summary
+    print("\n" + "="*80)
+    print("SEGMENT LENGTH STATISTICS")
+    print("="*80)
+    length_display_cols = ['segment', 'reads_with_length', 'mean_length', 'median_length',
+                           'std_length', 'min_length', 'p01_length', 'p05_length', 'max_length', 'outlier_percent']
+    print(length_stats_df.select(length_display_cols))
+
+    # Print anomaly summary if thresholds are specified
+    print_anomaly_summary(length_stats_df)
+
+    # Export anomalous reads if thresholds are specified
+    if anomaly_thresholds:
+        anomalous_file = output_dir / "anomalous_reads_valid.tsv"
+        export_anomalous_reads(lf, anomaly_thresholds, anomalous_file)
+
+    # Generate segment length visualizations
+    length_plot_file = output_dir / "segment_length_distributions.pdf"
+    plot_segment_length_distributions(lf, all_segments, segment_lengths, length_plot_file)
+    print(f"\nSaved length distribution plots to {length_plot_file}")
+
+    # ========== INVALID READS ANALYSIS (if provided) ==========
+    if args.invalid_parquet:
+        print("\n" + "="*80)
+        print("ANALYZING INVALID READS")
+        print("="*80)
+
+        # Load invalid data
+        print(f"\nScanning {args.invalid_parquet}...")
+        lf_invalid = pl.scan_parquet(args.invalid_parquet)
+
+        # Verify it has the same segments
+        schema_invalid = lf_invalid.collect_schema()
+        if "reason" not in schema_invalid:
+            print("WARNING: Invalid parquet file missing 'reason' column!")
+
+        # Add segment length columns for invalid reads
+        print("\nAdding segment length columns for invalid reads...")
+        lf_invalid = add_segment_length_columns(lf_invalid, all_segments)
+
+        # Add quality scores for invalid reads
+        print("\nComputing quality scores for invalid reads...")
+        lf_invalid = add_segment_scores(lf_invalid, all_segments, segment_lengths)
+
+        # Compute segment length statistics for invalid reads
+        length_stats_invalid_df = compute_segment_length_statistics(lf_invalid, all_segments, segment_lengths, anomaly_thresholds)
+
+        # Compute statistics for invalid reads
+        print("\nCalculating invalid read statistics...")
+        all_stats_invalid = []
+        for seg in all_segments:
+            print(f"  Processing {seg}...")
+            stats = compute_segment_statistics(
+                lf_invalid, seg, segment_lengths.get(seg), args.ont_error_rate
+            )
+            all_stats_invalid.append(stats)
+
+        stats_invalid_df = pl.DataFrame(all_stats_invalid)
+
+        # Save invalid statistics
+        stats_invalid_file = output_dir / "edit_distance_statistics_invalid.tsv"
+        stats_invalid_df.write_csv(stats_invalid_file, separator="\t")
+        print(f"\nSaved invalid read statistics to {stats_invalid_file}")
+
+        # Print invalid summary
+        print("\n" + "="*80)
+        print("INVALID READS SUMMARY STATISTICS")
+        print("="*80)
+        print(stats_invalid_df.select(display_cols))
+
+        # Compare valid vs invalid
+        print("\n" + "="*80)
+        print("VALID vs INVALID COMPARISON")
+        print("="*80)
+
+        # Detection rate comparison
+        comp_df = compare_detection_rates(all_stats, all_stats_invalid)
+        comp_file = output_dir / "valid_vs_invalid_comparison.tsv"
+        comp_df.write_csv(comp_file, separator="\t")
+        print(f"\nSaved comparison to {comp_file}")
+
+        # Generate comparison visualizations
+        comparison_plot_file = output_dir / "valid_vs_invalid_comparison.pdf"
+        plot_valid_vs_invalid_comparison(lf, lf_invalid, all_segments, segment_lengths, comparison_plot_file)
+        print(f"\nSaved comparison plots to {comparison_plot_file}")
+
+        # Generate quality score comparison
+        score_comparison_file = output_dir / "quality_score_comparison.pdf"
+        plot_score_comparison(lf, lf_invalid, all_segments, score_comparison_file)
+        print(f"\nSaved score comparison plots to {score_comparison_file}")
+
+        # Export ranked invalid reads
+        ranked_invalid_file = output_dir / "ranked_reads_invalid.tsv"
+        export_ranked_reads(lf_invalid, ranked_invalid_file, n_top=1000, n_bottom=1000)
+
+        # Save invalid segment length statistics
+        length_stats_invalid_file = output_dir / "segment_length_statistics_invalid.tsv"
+        length_stats_invalid_df.write_csv(length_stats_invalid_file, separator="\t")
+        print(f"\nSaved invalid segment length statistics to {length_stats_invalid_file}")
+
+        # Print invalid length summary
+        print("\n" + "="*80)
+        print("INVALID READS - SEGMENT LENGTH STATISTICS")
+        print("="*80)
+        print(length_stats_invalid_df.select(length_display_cols))
+
+        # Print anomaly summary for invalid reads
+        if anomaly_thresholds:
+            print("\n" + "="*80)
+            print("INVALID READS - ANOMALY DETECTION")
+            print("="*80)
+            print_anomaly_summary(length_stats_invalid_df)
+
+            # Export anomalous invalid reads
+            anomalous_invalid_file = output_dir / "anomalous_reads_invalid.tsv"
+            export_anomalous_reads(lf_invalid, anomaly_thresholds, anomalous_invalid_file)
+
+        # Generate segment length comparison
+        length_comparison_file = output_dir / "segment_length_comparison.pdf"
+        plot_length_comparison(lf, lf_invalid, all_segments, length_comparison_file)
+        print(f"\nSaved length comparison plots to {length_comparison_file}")
+
+        # Analyze invalid reads by failure reason (optional - can be slow)
+        if "reason" in schema_invalid and args.analyze_reasons:
+            reason_stats_df = analyze_invalid_by_reason(
+                lf_invalid, all_segments, segment_lengths, args.ont_error_rate, args.max_reasons
+            )
+
+            # Save reason breakdown
+            reason_file = output_dir / "invalid_by_reason.tsv"
+            reason_stats_df.write_csv(reason_file, separator="\t")
+            print(f"\nSaved reason breakdown to {reason_file}")
+
+            # Print top reasons summary
+            print("\n" + "="*80)
+            print("TOP FAILURE REASONS (by read count)")
+            print("="*80)
+
+            reason_summary = (
+                reason_stats_df
+                .group_by("reason")
+                .agg(pl.col("reason_count").first().alias("read_count"))
+                .sort("read_count", descending=True)
+                .head(10)
+            )
+            print(reason_summary)
+
+            # Generate reason breakdown plots
+            reason_plot_file = output_dir / "invalid_reason_breakdown.pdf"
+            plot_invalid_reason_breakdown(reason_stats_df, all_segments, reason_plot_file)
+            print(f"\nSaved reason breakdown plots to {reason_plot_file}")
+        elif "reason" in schema_invalid and not args.analyze_reasons:
+            print("\nSkipping failure reason analysis (use --analyze_reasons to enable)")
+            print("  Note: With many unique failure reasons, this can be slow")
 
     print("\n" + "="*80)
     print("ANALYSIS COMPLETE")
     print("="*80)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/utils/analyze_edit_distances.py
+++ b/utils/analyze_edit_distances.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""
+Analyze edit distance distributions for valid reads with ONT-specific thresholds.
+
+This script reads the annotations parquet file and generates:
+1. Summary statistics for edit distances per segment
+2. ONT-aware filtering thresholds based on segment length and expected error rates
+3. Visualizations of edit distance distributions
+4. Recommendations for filtering thresholds
+
+Usage:
+    python analyze_edit_distances.py <parquet_file> [--output_dir OUTPUT_DIR] [--ont_error_rate ONT_ERROR_RATE]
+"""
+
+import os
+import sys
+import argparse
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from matplotlib.backends.backend_pdf import PdfPages
+from pathlib import Path
+from math import ceil
+
+sns.set_style("whitegrid")
+
+def load_valid_reads(parquet_file):
+    """Load valid reads from parquet file."""
+    print(f"Loading data from {parquet_file}...")
+
+    # Try polars first (faster), fall back to pandas if needed
+    try:
+        import polars as pl
+        df = pl.read_parquet(parquet_file)
+        # Convert to pandas for easier manipulation
+        df = df.to_pandas()
+    except Exception as e:
+        print(f"Polars not available or failed ({e}), using pandas...")
+        df = pd.read_parquet(parquet_file)
+
+    print(f"Loaded {len(df):,} reads")
+    return df
+
+def identify_edit_distance_columns(df):
+    """Identify all edit distance columns in the DataFrame."""
+    edit_dist_cols = [col for col in df.columns if col.endswith('_edit_distance')]
+
+    # Categorize by segment type
+    barcode_segments = []
+    fixed_segments = []
+
+    for col in edit_dist_cols:
+        segment = col.replace('_edit_distance', '')
+        if segment in ['CBC', 'i7', 'i5']:
+            barcode_segments.append(segment)
+        else:
+            fixed_segments.append(segment)
+
+    return edit_dist_cols, barcode_segments, fixed_segments
+
+def get_segment_lengths(df, segments):
+    """Calculate median segment length for each segment."""
+    segment_lengths = {}
+
+    for segment in segments:
+        start_col = f'{segment}_Starts'
+        end_col = f'{segment}_Ends'
+
+        if start_col in df.columns and end_col in df.columns:
+            # Calculate lengths where both start and end are present
+            lengths = df[end_col] - df[start_col]
+            lengths = lengths[lengths > 0]  # Filter out invalid lengths
+
+            if len(lengths) > 0:
+                segment_lengths[segment] = lengths.median()
+            else:
+                # Fallback: estimate from sequence column if available
+                seq_col = f'{segment}_Sequences'
+                if seq_col in df.columns:
+                    seq_lengths = df[seq_col].dropna().str.len()
+                    if len(seq_lengths) > 0:
+                        segment_lengths[segment] = seq_lengths.median()
+
+    return segment_lengths
+
+def calculate_ont_threshold(segment_length, error_rate):
+    """
+    Calculate acceptable edit distance based on ONT error rate and segment length.
+
+    For ONT data with error_rate (e.g., 0.05 for 5%), the maximum acceptable
+    edit distance is: ceil(segment_length * error_rate)
+    """
+    if segment_length is None or segment_length == 0:
+        return None
+    return ceil(segment_length * error_rate)
+
+def calculate_statistics(df, segment, edit_dist_col, segment_length=None, ont_error_rate=0.05):
+    """Calculate comprehensive statistics for a segment's edit distances."""
+    values = df[edit_dist_col].dropna()
+
+    if len(values) == 0:
+        return None
+
+    # Calculate ONT-aware threshold if segment length is available
+    ont_threshold_strict = calculate_ont_threshold(segment_length, 0.02) if segment_length else None  # 2% error
+    ont_threshold_permissive = calculate_ont_threshold(segment_length, ont_error_rate) if segment_length else None  # User-specified (default 5%)
+    ont_threshold_very_permissive = calculate_ont_threshold(segment_length, 0.10) if segment_length else None  # 10% error
+
+    stats = {
+        'segment': segment,
+        'median_length': segment_length if segment_length else np.nan,
+        'total_reads': len(df),
+        'reads_with_segment': len(values),
+        'reads_missing_segment': len(df) - len(values),
+        'percent_detected': 100 * len(values) / len(df),
+
+        # Basic statistics
+        'mean': values.mean(),
+        'median': values.median(),
+        'std': values.std(),
+        'min': values.min(),
+        'max': values.max(),
+
+        # Percentiles
+        'p25': values.quantile(0.25),
+        'p75': values.quantile(0.75),
+        'p95': values.quantile(0.95),
+        'p99': values.quantile(0.99),
+
+        # Quality metrics
+        'perfect_matches': (values == 0).sum(),
+        'percent_perfect': 100 * (values == 0).sum() / len(values),
+        'edit_dist_1_or_less': (values <= 1).sum(),
+        'percent_ed1_or_less': 100 * (values <= 1).sum() / len(values),
+        'edit_dist_3_or_less': (values <= 3).sum(),
+        'percent_ed3_or_less': 100 * (values <= 3).sum() / len(values),
+        'edit_dist_5_or_less': (values <= 5).sum(),
+        'percent_ed5_or_less': 100 * (values <= 5).sum() / len(values),
+
+        # ONT-specific thresholds
+        'ont_threshold_2pct': ont_threshold_strict,
+        'ont_threshold_5pct': ont_threshold_permissive,
+        'ont_threshold_10pct': ont_threshold_very_permissive,
+    }
+
+    # Calculate percentage of reads passing ONT thresholds
+    if ont_threshold_strict is not None:
+        stats['percent_passing_2pct'] = 100 * (values <= ont_threshold_strict).sum() / len(values)
+    else:
+        stats['percent_passing_2pct'] = np.nan
+
+    if ont_threshold_permissive is not None:
+        stats['percent_passing_5pct'] = 100 * (values <= ont_threshold_permissive).sum() / len(values)
+    else:
+        stats['percent_passing_5pct'] = np.nan
+
+    if ont_threshold_very_permissive is not None:
+        stats['percent_passing_10pct'] = 100 * (values <= ont_threshold_very_permissive).sum() / len(values)
+    else:
+        stats['percent_passing_10pct'] = np.nan
+
+    return stats
+
+def plot_edit_distance_distributions(df, segments, segment_lengths, ont_error_rate, output_pdf):
+    """Create comprehensive visualizations of edit distance distributions."""
+    print(f"Creating visualizations in {output_pdf}...")
+
+    with PdfPages(output_pdf) as pdf:
+        # 1. Individual histograms for each segment
+        for segment in segments:
+            edit_dist_col = f'{segment}_edit_distance'
+            if edit_dist_col not in df.columns:
+                continue
+
+            values = df[edit_dist_col].dropna()
+            if len(values) == 0:
+                continue
+
+            segment_length = segment_lengths.get(segment)
+            ont_threshold_2pct = calculate_ont_threshold(segment_length, 0.02)
+            ont_threshold_5pct = calculate_ont_threshold(segment_length, ont_error_rate)
+            ont_threshold_10pct = calculate_ont_threshold(segment_length, 0.10)
+
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+            # Histogram
+            ax1.hist(values, bins=min(50, int(values.max()) + 1), edgecolor='black', alpha=0.7)
+            ax1.axvline(values.median(), color='red', linestyle='--',
+                       label=f'Median: {values.median():.1f}')
+
+            if ont_threshold_2pct is not None:
+                ax1.axvline(ont_threshold_2pct, color='green', linestyle='--',
+                           linewidth=2, label=f'ONT 2% error: {ont_threshold_2pct}')
+            if ont_threshold_5pct is not None:
+                ax1.axvline(ont_threshold_5pct, color='orange', linestyle='--',
+                           linewidth=2, label=f'ONT {int(ont_error_rate*100)}% error: {ont_threshold_5pct}')
+            if ont_threshold_10pct is not None:
+                ax1.axvline(ont_threshold_10pct, color='purple', linestyle='--',
+                           linewidth=2, label=f'ONT 10% error: {ont_threshold_10pct}')
+
+            ax1.set_xlabel('Edit Distance')
+            ax1.set_ylabel('Frequency')
+            title = f'{segment} Edit Distance Distribution'
+            if segment_length:
+                title += f'\n(median length: {segment_length:.0f} bp)'
+            ax1.set_title(title)
+            ax1.legend()
+            ax1.grid(True, alpha=0.3)
+
+            # Cumulative distribution
+            sorted_vals = np.sort(values)
+            cumulative = np.arange(1, len(sorted_vals) + 1) / len(sorted_vals)
+            ax2.plot(sorted_vals, cumulative, linewidth=2)
+
+            if ont_threshold_2pct is not None:
+                pct_passing = 100 * (values <= ont_threshold_2pct).sum() / len(values)
+                ax2.axvline(ont_threshold_2pct, color='green', linestyle='--',
+                           linewidth=2, alpha=0.7,
+                           label=f'ONT 2% threshold: {ont_threshold_2pct} ({pct_passing:.1f}% pass)')
+            if ont_threshold_5pct is not None:
+                pct_passing = 100 * (values <= ont_threshold_5pct).sum() / len(values)
+                ax2.axvline(ont_threshold_5pct, color='orange', linestyle='--',
+                           linewidth=2, alpha=0.7,
+                           label=f'ONT {int(ont_error_rate*100)}% threshold: {ont_threshold_5pct} ({pct_passing:.1f}% pass)')
+            if ont_threshold_10pct is not None:
+                pct_passing = 100 * (values <= ont_threshold_10pct).sum() / len(values)
+                ax2.axvline(ont_threshold_10pct, color='purple', linestyle='--',
+                           linewidth=2, alpha=0.7,
+                           label=f'ONT 10% threshold: {ont_threshold_10pct} ({pct_passing:.1f}% pass)')
+
+            ax2.set_xlabel('Edit Distance')
+            ax2.set_ylabel('Cumulative Fraction')
+            ax2.set_title(f'{segment} Cumulative Distribution')
+            ax2.legend()
+            ax2.grid(True, alpha=0.3)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+        # 2. Comparison box plot (all segments)
+        fig, ax = plt.subplots(figsize=(14, 6))
+
+        plot_data = []
+        plot_labels = []
+        ont_thresholds_2pct = []
+        ont_thresholds_5pct = []
+        ont_thresholds_10pct = []
+
+        for segment in segments:
+            edit_dist_col = f'{segment}_edit_distance'
+            if edit_dist_col in df.columns:
+                values = df[edit_dist_col].dropna()
+                if len(values) > 0:
+                    plot_data.append(values)
+                    plot_labels.append(segment)
+
+                    segment_length = segment_lengths.get(segment)
+                    ont_thresholds_2pct.append(calculate_ont_threshold(segment_length, 0.02))
+                    ont_thresholds_5pct.append(calculate_ont_threshold(segment_length, ont_error_rate))
+                    ont_thresholds_10pct.append(calculate_ont_threshold(segment_length, 0.10))
+
+        if plot_data:
+            bp = ax.boxplot(plot_data, labels=plot_labels, patch_artist=True,
+                           showfliers=False)  # Hide outliers for clarity
+
+            # Color barcode segments differently from fixed segments
+            for i, (patch, label) in enumerate(zip(bp['boxes'], plot_labels)):
+                if label in ['CBC', 'i7', 'i5']:
+                    patch.set_facecolor('lightblue')
+                else:
+                    patch.set_facecolor('lightcoral')
+
+            # Plot ONT thresholds as horizontal lines per segment
+            x_positions = range(1, len(plot_labels) + 1)
+            for i, (x, thr_2, thr_5, thr_10) in enumerate(zip(x_positions, ont_thresholds_2pct, ont_thresholds_5pct, ont_thresholds_10pct)):
+                if thr_2 is not None:
+                    ax.plot([x-0.3, x+0.3], [thr_2, thr_2], 'g-', linewidth=2, alpha=0.7)
+                if thr_5 is not None:
+                    ax.plot([x-0.3, x+0.3], [thr_5, thr_5], 'orange', linewidth=2, alpha=0.7)
+                if thr_10 is not None:
+                    ax.plot([x-0.3, x+0.3], [thr_10, thr_10], 'purple', linewidth=2, alpha=0.7)
+
+            ax.set_ylabel('Edit Distance')
+            ax.set_title('Edit Distance Comparison Across Segments')
+            ax.tick_params(axis='x', rotation=45)
+            ax.grid(True, alpha=0.3, axis='y')
+
+            # Add legend
+            from matplotlib.patches import Patch
+            from matplotlib.lines import Line2D
+            legend_elements = [
+                Patch(facecolor='lightblue', label='Barcode segments'),
+                Patch(facecolor='lightcoral', label='Fixed segments'),
+                Line2D([0], [0], color='green', linewidth=2, label='ONT 2% error threshold'),
+                Line2D([0], [0], color='orange', linewidth=2, label=f'ONT {int(ont_error_rate*100)}% error threshold'),
+                Line2D([0], [0], color='purple', linewidth=2, label='ONT 10% error threshold')
+            ]
+            ax.legend(handles=legend_elements, loc='upper right')
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+        # 3. Error rate distribution plot (edit distance / segment length)
+        fig, ax = plt.subplots(figsize=(12, 6))
+
+        error_rate_data = []
+        error_rate_labels = []
+
+        for segment in segments:
+            edit_dist_col = f'{segment}_edit_distance'
+            segment_length = segment_lengths.get(segment)
+
+            if edit_dist_col in df.columns and segment_length and segment_length > 0:
+                values = df[edit_dist_col].dropna()
+                if len(values) > 0:
+                    # Calculate error rates as percentages
+                    error_rates = (values / segment_length) * 100
+                    error_rate_data.append(error_rates)
+                    error_rate_labels.append(f'{segment}\n({segment_length:.0f}bp)')
+
+        if error_rate_data:
+            bp = ax.boxplot(error_rate_data, labels=error_rate_labels, patch_artist=True,
+                           showfliers=False)
+
+            # Color barcode segments differently
+            for i, (patch, label) in enumerate(zip(bp['boxes'], error_rate_labels)):
+                segment_name = label.split('\n')[0]
+                if segment_name in ['CBC', 'i7', 'i5']:
+                    patch.set_facecolor('lightblue')
+                else:
+                    patch.set_facecolor('lightcoral')
+
+            # Add reference lines for 2%, 5%, and 10% error
+            ax.axhline(2, color='green', linestyle='--', linewidth=2, alpha=0.7, label='2% error rate')
+            ax.axhline(ont_error_rate * 100, color='orange', linestyle='--', linewidth=2, alpha=0.7,
+                      label=f'{int(ont_error_rate*100)}% error rate')
+            ax.axhline(10, color='purple', linestyle='--', linewidth=2, alpha=0.7, label='10% error rate')
+
+            ax.set_ylabel('Error Rate (%)')
+            ax.set_title('Error Rate Distribution Across Segments\n(Edit Distance / Segment Length)')
+            ax.tick_params(axis='x', rotation=45)
+            ax.grid(True, alpha=0.3, axis='y')
+            ax.legend()
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+        # 4. Heatmap of correlation between segment edit distances
+        if len(segments) > 1:
+            edit_dist_df = df[[f'{seg}_edit_distance' for seg in segments
+                              if f'{seg}_edit_distance' in df.columns]].copy()
+            edit_dist_df.columns = [col.replace('_edit_distance', '') for col in edit_dist_df.columns]
+
+            if len(edit_dist_df.columns) > 1:
+                fig, ax = plt.subplots(figsize=(10, 8))
+                corr = edit_dist_df.corr()
+                sns.heatmap(corr, annot=True, fmt='.2f', cmap='coolwarm', center=0,
+                           square=True, ax=ax, cbar_kws={'label': 'Correlation'})
+                ax.set_title('Edit Distance Correlation Between Segments')
+                plt.tight_layout()
+                pdf.savefig()
+                plt.close()
+
+def generate_filtering_recommendations(stats_df, ont_error_rate):
+    """Generate filtering threshold recommendations based on statistics."""
+    print("\n" + "="*80)
+    print("FILTERING RECOMMENDATIONS")
+    print("="*80)
+
+    recommendations = []
+
+    for _, row in stats_df.iterrows():
+        segment = row['segment']
+
+        # ONT-aware thresholds (preferred for ONT data)
+        ont_threshold_2pct = row['ont_threshold_2pct']
+        ont_threshold_5pct = row['ont_threshold_5pct']
+        ont_threshold_10pct = row['ont_threshold_10pct']
+
+        # Data-driven thresholds (95th and 99th percentiles)
+        p95_threshold = row['p95']
+        p99_threshold = row['p99']
+
+        # Strict threshold (only perfect or near-perfect matches)
+        strict_threshold = 1 if row['percent_ed1_or_less'] > 80 else 2
+
+        rec = {
+            'segment': segment,
+            'median_length': row['median_length'],
+            'ont_threshold_2pct': ont_threshold_2pct,
+            'ont_threshold_5pct': ont_threshold_5pct,
+            'ont_threshold_10pct': ont_threshold_10pct,
+            'percent_passing_2pct': row['percent_passing_2pct'],
+            'percent_passing_5pct': row['percent_passing_5pct'],
+            'percent_passing_10pct': row['percent_passing_10pct'],
+            'strict_threshold': strict_threshold,
+            'p95_threshold': p95_threshold,
+            'p99_threshold': p99_threshold,
+            'percent_perfect': row['percent_perfect'],
+        }
+
+        recommendations.append(rec)
+
+        print(f"\n{segment} (median length: {row['median_length']:.0f} bp):")
+        print(f"  Perfect matches: {row['percent_perfect']:.1f}%")
+        print(f"  Median edit distance: {row['median']:.1f}")
+        print(f"\n  ONT-based thresholds (recommended for ONT data):")
+        if not np.isnan(ont_threshold_2pct):
+            print(f"    - Conservative (2% error):       edit_distance <= {ont_threshold_2pct} ({row['percent_passing_2pct']:.1f}% of reads)")
+        if not np.isnan(ont_threshold_5pct):
+            print(f"    - Permissive ({int(ont_error_rate*100)}% error):        edit_distance <= {ont_threshold_5pct} ({row['percent_passing_5pct']:.1f}% of reads)")
+        if not np.isnan(ont_threshold_10pct):
+            print(f"    - Very permissive (10% error):   edit_distance <= {ont_threshold_10pct} ({row['percent_passing_10pct']:.1f}% of reads)")
+
+        print(f"\n  Data-driven thresholds:")
+        print(f"    - Very strict (perfect only):       edit_distance <= {strict_threshold}")
+        print(f"    - 95th percentile:                  edit_distance <= {p95_threshold:.0f}")
+        print(f"    - 99th percentile:                  edit_distance <= {p99_threshold:.0f}")
+
+    print("\n" + "="*80)
+    print("RECOMMENDED FILTERING CODE (ONT-aware)")
+    print("="*80)
+    print("\nimport pandas as pd")
+    print("df = pd.read_parquet('annotations_valid.parquet')")
+
+    print("\n# Conservative filtering (2% error rate - high quality)")
+    print("df_conservative = df[")
+    for rec in recommendations:
+        if not np.isnan(rec['ont_threshold_2pct']):
+            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_2pct']}) &")
+    print("].copy()")
+
+    print("\n# Permissive filtering (5% error rate - balance quality/quantity)")
+    print("df_permissive = df[")
+    for rec in recommendations:
+        if not np.isnan(rec['ont_threshold_5pct']):
+            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_5pct']}) &")
+    print("].copy()")
+
+    print("\n# Very permissive filtering (10% error rate - maximum read retention)")
+    print("df_very_permissive = df[")
+    for rec in recommendations:
+        if not np.isnan(rec['ont_threshold_10pct']):
+            print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['ont_threshold_10pct']}) &")
+    print("].copy()")
+
+    print("\n# Data-driven filtering (95th percentile)")
+    print("df_p95 = df[")
+    for rec in recommendations:
+        print(f"    (df['{rec['segment']}_edit_distance'] <= {rec['p95_threshold']:.0f}) &")
+    print("].copy()")
+
+    print("\n" + "="*80)
+    print("INTERPRETATION GUIDE")
+    print("="*80)
+    print("""
+ONT-based thresholds account for segment length:
+  - Shorter segments (e.g., UMI ~12bp) tolerate fewer errors
+  - Longer segments (e.g., p5 ~25bp) can have more errors while staying under error %
+  - 2% error threshold: conservative, high-quality filtering
+  - 5% error threshold: permissive, within typical ONT specs (2-5% error rate)
+  - 10% error threshold: very permissive, for maximum read retention or lower quality runs
+
+Data-driven thresholds (percentiles) show your actual data distribution:
+  - Compare ONT thresholds vs percentiles to see if data matches expectations
+  - If p95 >> ONT 5% threshold: data may have quality issues
+  - If p95 ≈ ONT 5% threshold: data quality matches ONT expectations
+  - If p95 << ONT 5% threshold: data quality is better than expected
+""")
+
+    return pd.DataFrame(recommendations)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze edit distance distributions in annotated reads with ONT-specific thresholds'
+    )
+    parser.add_argument('parquet_file', help='Path to annotations parquet file')
+    parser.add_argument('--output_dir', '-o',
+                       help='Output directory for results (default: same as input file)',
+                       default=None)
+    parser.add_argument('--ont_error_rate', '-e', type=float, default=0.05,
+                       help='Expected ONT error rate (default: 0.05 = 5%%)')
+
+    args = parser.parse_args()
+
+    # Set output directory
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    else:
+        output_dir = Path(args.parquet_file).parent
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load data
+    df = load_valid_reads(args.parquet_file)
+
+    # Identify edit distance columns
+    edit_dist_cols, barcode_segments, fixed_segments = identify_edit_distance_columns(df)
+    all_segments = barcode_segments + fixed_segments
+
+    if not edit_dist_cols:
+        print("ERROR: No edit distance columns found in the parquet file!")
+        print("Available columns:", df.columns.tolist())
+        sys.exit(1)
+
+    print(f"\nFound edit distance columns for {len(all_segments)} segments:")
+    print(f"  Barcode segments: {', '.join(barcode_segments)}")
+    print(f"  Fixed segments: {', '.join(fixed_segments)}")
+
+    # Calculate segment lengths
+    print("\nCalculating median segment lengths...")
+    segment_lengths = get_segment_lengths(df, all_segments)
+    for segment, length in segment_lengths.items():
+        print(f"  {segment}: {length:.0f} bp")
+
+    # Calculate statistics for each segment
+    print(f"\nCalculating statistics (ONT error rate: {args.ont_error_rate*100:.0f}%)...")
+    stats_list = []
+    for segment in all_segments:
+        edit_dist_col = f'{segment}_edit_distance'
+        segment_length = segment_lengths.get(segment)
+        stats = calculate_statistics(df, segment, edit_dist_col,
+                                     segment_length=segment_length,
+                                     ont_error_rate=args.ont_error_rate)
+        if stats:
+            stats_list.append(stats)
+
+    stats_df = pd.DataFrame(stats_list)
+
+    # Save statistics to TSV
+    stats_file = output_dir / 'edit_distance_statistics.tsv'
+    stats_df.to_csv(stats_file, sep='\t', index=False, float_format='%.2f')
+    print(f"\nSaved statistics to {stats_file}")
+
+    # Print summary table
+    print("\n" + "="*80)
+    print("SUMMARY STATISTICS")
+    print("="*80)
+    display_cols = ['segment', 'median_length', 'reads_with_segment', 'percent_perfect',
+                    'median', 'ont_threshold_2pct', 'percent_passing_2pct',
+                    'ont_threshold_5pct', 'percent_passing_5pct',
+                    'ont_threshold_10pct', 'percent_passing_10pct']
+    print(stats_df[display_cols].to_string(index=False))
+
+    # Create visualizations
+    plot_file = output_dir / 'edit_distance_distributions.pdf'
+    plot_edit_distance_distributions(df, all_segments, segment_lengths,
+                                     args.ont_error_rate, plot_file)
+    print(f"\nSaved visualizations to {plot_file}")
+
+    # Generate filtering recommendations
+    recommendations_df = generate_filtering_recommendations(stats_df, args.ont_error_rate)
+    rec_file = output_dir / 'filtering_recommendations.tsv'
+    recommendations_df.to_csv(rec_file, sep='\t', index=False, float_format='%.1f')
+    print(f"\nSaved recommendations to {rec_file}")
+
+    print("\n" + "="*80)
+    print("ANALYSIS COMPLETE")
+    print("="*80)
+
+if __name__ == '__main__':
+    main()

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -112,7 +112,10 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                         chunk_size, gpu_mem, target_tokens,
                         vram_headroom, min_batch_size, max_batch_size,
                         bc_lv_threshold, threads, max_queue_size,
-                        whitelist_base_dir=None):
+                        whitelist_base_dir=None,
+                        include_edit_distances=False,
+                        include_sequences_in_valid_output=False,
+                        whitelist_paths=None):
     (os, gc, sys, resource, pickle, mp, Manager,
      defaultdict, psutil, pl, FileLock, pd,
      model_predictions, post_process_reads,
@@ -271,7 +274,10 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                     ambiguous_fasta_lock, threads,
                     seq_orders_path=seq_order_file,
                     model_name=model_name,
-                    whitelist_base_dir=whitelist_base_dir
+                    whitelist_base_dir=whitelist_base_dir,
+                    include_edit_distances=include_edit_distances,
+                    include_sequences_in_valid_output=include_sequences_in_valid_output,
+                    whitelist_paths=whitelist_paths
                 )
 
                 if result:

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -22,7 +22,9 @@ def load_libs():
 
     from filelock import FileLock
 
-    from scripts.export_annotations import (
+    # Switch to new export file to test integration with calculating
+    # edit distances to all segments (e.g. cbc, i5, i7, p5, p7, etc.)
+    from scripts.export_annotations_with_edit_distances import (
         post_process_reads,
         plot_read_n_cDNA_lengths,
     )
@@ -109,7 +111,8 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                         model_name, model_type, seq_order_file,
                         chunk_size, gpu_mem, target_tokens,
                         vram_headroom, min_batch_size, max_batch_size,
-                        bc_lv_threshold, threads, max_queue_size):
+                        bc_lv_threshold, threads, max_queue_size,
+                        whitelist_base_dir=None):
     (os, gc, sys, resource, pickle, mp, Manager,
      defaultdict, psutil, pl, FileLock, pd,
      model_predictions, post_process_reads,
@@ -245,6 +248,9 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                 # -- ambiguous_fasta
                 # -- ambiguous_fasta_lock
                 # -- threads
+                # -- seq_order_file (for edit distances)
+                # -- model_name (for edit distances)
+                # -- whitelist_base_dir (for edit distances)
                 result = post_process_reads(
                     reads, read_names, strand, output_fmt,
                     base_qualities, model_type,
@@ -262,7 +268,10 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                     local_cell_counter, demuxed_fasta,
                     demuxed_fasta_lock,
                     ambiguous_fasta,
-                    ambiguous_fasta_lock, threads
+                    ambiguous_fasta_lock, threads,
+                    seq_orders_path=seq_order_file,
+                    model_name=model_name,
+                    whitelist_base_dir=whitelist_base_dir
                 )
 
                 if result:
@@ -423,6 +432,8 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
 
     if model_type == "CRF":
         # process all the reads with CNN-LSTM-CRF model
+        # Fixme: should not assume specific suffixes - dynamically check
+        # and provide messages to the user about if it exits or not.
         model_path_w_CRF = f"{models_dir}/{model_name}_w_CRF.h5"
 
         with open(f"{models_dir}/{model_name}_w_CRF_lbl_bin.pkl", "rb") as f:

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -112,7 +112,6 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                         chunk_size, gpu_mem, target_tokens,
                         vram_headroom, min_batch_size, max_batch_size,
                         bc_lv_threshold, threads, max_queue_size,
-                        whitelist_base_dir=None,
                         include_edit_distances=False,
                         include_sequences_in_valid_output=False,
                         whitelist_paths=None):
@@ -253,7 +252,6 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                 # -- threads
                 # -- seq_order_file (for edit distances)
                 # -- model_name (for edit distances)
-                # -- whitelist_base_dir (for edit distances)
                 result = post_process_reads(
                     reads, read_names, strand, output_fmt,
                     base_qualities, model_type,
@@ -274,7 +272,6 @@ def annotate_reads_wrap(output_dir, whitelist_file, output_fmt,
                     ambiguous_fasta_lock, threads,
                     seq_orders_path=seq_order_file,
                     model_name=model_name,
-                    whitelist_base_dir=whitelist_base_dir,
                     include_edit_distances=include_edit_distances,
                     include_sequences_in_valid_output=include_sequences_in_valid_output,
                     whitelist_paths=whitelist_paths


### PR DESCRIPTION
This will be a larger PR, but it currently supports what I was hoping it would by emitting edit distances to known segments based on the `seq_orders.tsv` and whitelists. More details to come, but I have added a modified `export_annotations_with_edit_distances.py` that lives in parallel to the original `export_annotations.py`. Eventually, if we go through with this PR, can collapse the `export_annotations_with_edit_distances.py` into the original `export_annotations.py`.