### PR TITLE
New default model and several performance enhancements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
          curl -L "https://www.dropbox.com/scl/fi/inz070k8k7kfpibnj9lkt/10x3p_sc_ont_013_lbl_bin.pkl?rlkey=pwhonyomb3i4d13yjat8cxpro&dl=0" -o models/10x3p_sc_ont_013_lbl_bin.pkl
          curl -L "https://www.dropbox.com/scl/fi/9203pc2gz45u419kze446/hg38_gencode_chr21.fa?rlkey=k1co80pso7zsvb8oiqqc1o1dy&st=e0e92h5h&dl=1" -o tests/references/hg38_gencode_chr21.fa
          curl -L "https://www.dropbox.com/scl/fi/9zvh26moro7frfho818ko/hg38_gencode_chr21.gtf?rlkey=v3s05m9ap3srpjhvl5yfjfeq7&st=hn6mufoq&dl=0" -o tests/references/hg38_gencode_chr21.gtf
+         curl -L "https://www.dropbox.com/scl/fi/98ykmaori9zrqf0q1qn36/hg38.HouseKeepingGenes.bed.gz?rlkey=dqjabcby9b9owso30njfpauyt&st=zmvxk4pp&dl=0" -o tests/references/hg38.HouseKeepingGenes.bed.gz
 
       - name: Run Pytest with coverage
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
         shell: bash -l {0}
         run: |
          mkdir -p tests/10x3p/data tests/references
-         curl -L "https://www.dropbox.com/scl/fi/k18rs7icrw7la7ogoi9bh/10x3p_sc_ont_013.h5?rlkey=ssw6ylhpvwe3e96jmwm0j3pzg&st=5byhrx7t&dl=0" -o models/10x3p_sc_ont_013.h5
-         curl -L "https://www.dropbox.com/scl/fi/2plk01thb9q1o8gqgmgks/10x3p_sc_ont_013_params.yaml?rlkey=twtqwmpsyv6ecqeh7a2c5k6tx&dl=0" -o models/10x3p_sc_ont_013_params.yaml
-         curl -L "https://www.dropbox.com/scl/fi/inz070k8k7kfpibnj9lkt/10x3p_sc_ont_013_lbl_bin.pkl?rlkey=pwhonyomb3i4d13yjat8cxpro&dl=0" -o models/10x3p_sc_ont_013_lbl_bin.pkl
+         curl -L "https://www.dropbox.com/scl/fi/gmmifxp964fe66qvv3nfk/10x3p_sc_ont_016.h5?rlkey=vqqob3hxrqsuq8540su1aw985&st=bwk2kblf&dl=0" -o models/10x3p_sc_ont_016.h5
+         curl -L "https://www.dropbox.com/scl/fi/7almukao9vykewf4p73eg/10x3p_sc_ont_016_params.yaml?rlkey=ge8fhouxvvya3umlzryk8mvtq&st=zn01vxqc&dl=0" -o models/10x3p_sc_ont_016_params.yaml
+         curl -L "https://www.dropbox.com/scl/fi/4wvup62v1sgh7v84899ud/10x3p_sc_ont_016_lbl_bin.pkl?rlkey=m0xt4vzdpfc0ztj91zw93ko8p&st=y5skyjsq&dl=0" -o models/10x3p_sc_ont_016_lbl_bin.pkl
          curl -L "https://www.dropbox.com/scl/fi/9203pc2gz45u419kze446/hg38_gencode_chr21.fa?rlkey=k1co80pso7zsvb8oiqqc1o1dy&st=e0e92h5h&dl=1" -o tests/references/hg38_gencode_chr21.fa
          curl -L "https://www.dropbox.com/scl/fi/9zvh26moro7frfho818ko/hg38_gencode_chr21.gtf?rlkey=v3s05m9ap3srpjhvl5yfjfeq7&st=hn6mufoq&dl=0" -o tests/references/hg38_gencode_chr21.gtf
          curl -L "https://www.dropbox.com/scl/fi/98ykmaori9zrqf0q1qn36/hg38.HouseKeepingGenes.bed.gz?rlkey=dqjabcby9b9owso30njfpauyt&st=zmvxk4pp&dl=0" -o tests/references/hg38.HouseKeepingGenes.bed.gz

--- a/docs/webpages/model_training/assess_model.qmd
+++ b/docs/webpages/model_training/assess_model.qmd
@@ -146,6 +146,8 @@ pannable plots with hover tooltips. This is the primary artifact for reviewing m
 | `--transcriptome` | TEXT | None | Transcriptome FASTA for realistic cDNA | Recommended for realistic assessment |
 | `--min-spacer` | INT | 0 | Minimum spacer length between concatenated fragments | Adjust if your data has inter-fragment cDNA |
 | `--max-spacer` | INT | 50 | Maximum spacer length between concatenated fragments | Adjust if your data has inter-fragment cDNA |
+| `--min-flank` | INT | 0 | Minimum length of random cDNA flank at each terminal end of a read | Rarely changed |
+| `--max-flank` | INT | 50 | Maximum length of random cDNA flank at each terminal end of a read | Raise (e.g. 200–300) to cover real ONT adapter-flank lengths and reduce edge false positives |
 | `--max-trunc-5p` | INT | 0 | Max 5' truncation (bp) | Enable to test truncated read handling |
 | `--max-trunc-3p` | INT | 0 | Max 3' truncation (bp) | Enable to test truncated read handling |
 | `--threads` | INT | 2 | CPU threads | Increase for faster simulation |

--- a/docs/webpages/model_training/assess_model.qmd
+++ b/docs/webpages/model_training/assess_model.qmd
@@ -164,7 +164,7 @@ pannable plots with hover tooltips. This is the primary artifact for reviewing m
 
 ```bash
 tranquillyzer assess-model \
-    10x3p_sc_ont_013 \
+    10x3p_sc_ont_016 \
     models/ \
     assessment_output/ \
     --num-reads 500 \

--- a/docs/webpages/model_training/simulate_data_cli.qmd
+++ b/docs/webpages/model_training/simulate_data_cli.qmd
@@ -29,6 +29,10 @@ For background on how reads are simulated and why, see [Read Structure Simulatio
 | `--rc` / `--no-rc` | FLAG | `--rc` | Include reverse complements (doubles the training set) | Disable only if your protocol has a fixed known orientation |
 | `--transcriptome` | TEXT | None | Transcriptome FASTA for realistic cDNA generation | Recommended — improves model accuracy on real data |
 | `--invalid-fraction` | FLOAT | 0.3 | Fraction of reads generated as structurally invalid artifacts | Increase if your data has many malformed reads |
+| `--min-spacer` | INT | 0 | Minimum length of random cDNA spacer between concatenated fragments | Rarely changed |
+| `--max-spacer` | INT | 50 | Maximum length of random cDNA spacer between concatenated fragments | Raise to cover longer real chimeric junctions |
+| `--min-flank` | INT | 0 | Minimum length of random cDNA flank at each terminal end of a read | Rarely changed |
+| `--max-flank` | INT | 50 | Maximum length of random cDNA flank at each terminal end of a read | Raise (e.g. 200–300) to cover real ONT adapter-flank lengths and reduce edge false positives |
 
 # Example Usage
 

--- a/docs/webpages/model_training/train_model.qmd
+++ b/docs/webpages/model_training/train_model.qmd
@@ -50,8 +50,9 @@ Reads are converted to integer tokens before training:
 | T | 4 |
 | N | 5 |
 
-This mapping is governed by the `vocab_size` parameter (default: 5, for the five nucleotide symbols). The padding token
-(0) is used only to make reads within a batch the same length and does not represent a nucleotide.
+This mapping is governed by the `vocab_size` parameter (default: 6, covering the four DNA bases, the ambiguity
+symbol `N`, and the padding token). The padding token (0) is used only to make reads within a batch the same length
+and does not represent a nucleotide.
 
 ## Embedding Layer
 
@@ -79,7 +80,7 @@ The key parameters are:
 
 - **`conv_kernel_size`** (default: 25): how wide a motif each layer can detect at once. Larger kernels help detect
   longer protocol motifs and smooth local noise, but values that are too large may blur sharp boundary cues.
-- **`conv_filters`** (default: 128 per layer): the number of distinct motif detectors per layer. More filters means
+- **`conv_filters`** (default: 64 per layer): the number of distinct motif detectors per layer. More filters means
   more pattern capacity at the cost of memory and compute. If boundaries are being missed or adapters vary across
   reads, increasing filters is often more effective than adding more layers.
 - **`conv_layers`** (default: 3): how many convolutional stages are stacked. More layers allow hierarchical motif
@@ -109,7 +110,7 @@ sequence in order and retaining information over long distances.
 _Tranquillyzer_ uses a **bidirectional** LSTM by default, meaning it reads the sequence both left-to-right and
 right-to-left. This allows each position to be interpreted using context from both sides.
 
-- **`lstm_units`** (default: 96): the size of the LSTM's internal memory. Increasing units improves the model's ability
+- **`lstm_units`** (default: 32): the size of the LSTM's internal memory. Increasing units improves the model's ability
   to track long-range structure but increases compute and can overfit.
 - **`lstm_layers`** (default: 1): stacking multiple LSTMs increases modeling power but is often unnecessary for
   standard protocols.

--- a/docs/webpages/model_training/train_model_cli.qmd
+++ b/docs/webpages/model_training/train_model_cli.qmd
@@ -55,14 +55,14 @@ parameter values. If you want to search over multiple values for a parameter, pr
 10x3p_sc_ont:
   batch_size: 128
   train_fraction: 0.8
-  vocab_size: 5
+  vocab_size: 6
   embedding_dim: 128
   conv_layers: 3
-  conv_filters: [128, 128, 128]
+  conv_filters: [64, 64, 64]
   conv_kernel_sizes: [25, 25, 25]
-  dilation_rates: [1, 3, 5]
+  dilation_rates: [1, 1, 1]
   lstm_layers: 1
-  lstm_units: [96]
+  lstm_units: [32]
   bidirectional: true
   crf_layer: true
   attention_heads: 0
@@ -100,14 +100,14 @@ other _Tranquillyzer_ commands.
 10x3p_sc_ont:
   batch_size: 128
   train_fraction: 0.8
-  vocab_size: 5
+  vocab_size: 6
   embedding_dim: 128
   conv_layers: 3
-  conv_filters: [128, 128, 128]
+  conv_filters: [64, 64, 64]
   conv_kernel_sizes: [25, 25, 25]
-  dilation_rates: [1, 3, 5]
+  dilation_rates: [1, 1, 1]
   lstm_layers: 1
-  lstm_units: [96]
+  lstm_units: [32]
   bidirectional: true
   crf_layer: true
   attention_heads: 0

--- a/docs/webpages/pipeline/annotation.qmd
+++ b/docs/webpages/pipeline/annotation.qmd
@@ -26,7 +26,7 @@ whitelist-free workflow):
 
 ```bash
 tranquillyzer annotate-reads \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     --threads 12 \
     OUTPUT_DIR
@@ -38,7 +38,7 @@ Use this when you have a whitelist and want the fastest path to demultiplexed re
 
 ```bash
 tranquillyzer annotate-reads \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     --threads 12 \
     --run-barcode-correction \
@@ -69,7 +69,7 @@ automatically pick up from the last completed chunk. Progress is tracked in a ch
 |---|:--:|---|---|
 | `OUTPUT_DIR` | required | Base output directory | |
 | `WHITELIST_FILE` | optional | Barcode whitelist TSV | Required if using `--run-barcode-correction` |
-| `--model-name` | `10x3p_sc_ont_013` | Model to use for inference | Set to match your protocol |
+| `--model-name` | `10x3p_sc_ont_016` | Model to use for inference | Set to match your protocol |
 | `--seq-order-file` | `utils/seq_orders.yaml` | Library definition file | Only if using a custom file |
 | `--gpu-mem` | 12 GB | GPU memory budget | Always set to your actual VRAM |
 | `--target-tokens` | 1,200,000 | Token budget per GPU | See [Resource Requirements](resource_requirements.qmd) |

--- a/docs/webpages/pipeline/barcode_demux.qmd
+++ b/docs/webpages/pipeline/barcode_demux.qmd
@@ -73,7 +73,7 @@ tranquillyzer barcode-correct \
 | `INPUT_DIR` | required | Directory containing annotation_metadata/ | |
 | `WHITELIST_FILE` | required | TSV with barcode columns | |
 | `--output-dir` | `INPUT_DIR` | Where to write corrected output | Set if you want separate output |
-| `--model-name` | `10x3p_sc_ont_013` | Model for barcode column resolution | Match your annotation model |
+| `--model-name` | `10x3p_sc_ont_016` | Model for barcode column resolution | Match your annotation model |
 | `--bc-lv-threshold` | 2 | Max Levenshtein distance for fuzzy matching | Increase for noisier barcodes |
 | `--run-demux` | off | Demultiplex concurrently | Enable to get FASTA/FASTQ output |
 | `--output-fmt` | `fasta` | Demux format | Use `fastq` if quality scores available |
@@ -92,7 +92,7 @@ using count-based knee-point detection.
 
 ```bash
 tranquillyzer annotate-reads \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     OUTPUT_DIR
 ```
@@ -101,7 +101,7 @@ tranquillyzer annotate-reads \
 
 ```bash
 tranquillyzer generate-whitelist \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --expected-cells 5000 \
     OUTPUT_DIR
 ```
@@ -126,7 +126,7 @@ tranquillyzer generate-whitelist \
 | Option | Default | Description | When to change |
 |---|:--:|---|---|
 | `OUTPUT_DIR` | required | Annotation output directory | |
-| `--model-name` | `10x3p_sc_ont_013` | Model for barcode column resolution | Match your annotation model |
+| `--model-name` | `10x3p_sc_ont_016` | Model for barcode column resolution | Match your annotation model |
 | `--expected-cells` | None (auto) | Hint for expected number of cells | Provide if known for better knee detection |
 | `--min-cell-ratio` | 0.50 | Knee threshold as fraction of cliff-top count | Lower to include more cells; raise for stricter filtering |
 | `--min-reads-per-barcode` | 3 | Minimum reads for a barcode to be considered | Increase for noisier data |

--- a/docs/webpages/pipeline/qc_metrics.qmd
+++ b/docs/webpages/pipeline/qc_metrics.qmd
@@ -33,7 +33,7 @@ Providing an aligned BAM file (with CB and UB tags) enables:
 - **Unique UMIs per cell**
 - **Mapping rate per cell**
 - **Duplicate rate per cell**
-- **Gene body coverage** (also requires `--gtf`)
+- **Gene body coverage** (also requires `--gene-body-bed`)
 
 ## Tier 3: Gene Quantification Metrics (Requires `--counts-matrix` and `--gtf`)
 
@@ -66,8 +66,29 @@ tranquillyzer qc-metrics \
     --bam aligned_files/dup_marked.bam \
     --counts-matrix counts_matrix.tsv \
     --gtf gencode.v44.annotation.gtf \
+    --gene-body-bed hg38.HouseKeepingGenes.bed.gz \
     INPUT_DIR
 ```
+
+## Gene Body Coverage
+
+The gene body coverage plot follows the [RSeQC convention](https://rseqc.sourceforge.net/#genebody-coverage-py):
+the user supplies a curated BED12 (one transcript per line) via `--gene-body-bed`, and each line is treated
+independently in the pileup. No transcript is auto-picked from the GTF — supplying a curated BED keeps the
+percentile axis aligned with the canonical mRNA species and avoids artifacts from extended-UTR or retained-intron
+isoforms. Both plain and gzipped BED12 are accepted.
+
+Common sources for the BED:
+
+- **RSeQC housekeeping BEDs** ([SourceForge](https://sourceforge.net/projects/rseqc/files/BED/)) — pre-curated
+  single-isoform-per-gene sets for hg38, hg19, mm10, etc. The fastest path to a clean curve.
+- **MANE_Select export** — for human, the ~19,000 MANE_Select transcripts converted to BED12 (e.g. via UCSC
+  `gtfToGenePred` + `genePredToBed`).
+- **Custom curated set** — any BED12 the user trusts (e.g. APPRIS principal isoforms, project-specific genes
+  of interest).
+
+Without `--gene-body-bed`, the gene body coverage plot is omitted from the report (other QC sections are
+unaffected).
 
 # Command Line Options
 
@@ -81,7 +102,8 @@ tranquillyzer qc-metrics \
 | `--invalid-file` | auto-detect | Path to invalid annotations parquet | Only if non-standard location |
 | `--bam` | None | Coordinate-sorted BAM with CB/UB tags | Provide for saturation and alignment metrics |
 | `--counts-matrix` | None | featureCounts counts matrix TSV | Provide for gene-level QC |
-| `--gtf` | None | GTF annotation file | Required with `--counts-matrix`; also used for gene body coverage |
+| `--gtf` | None | GTF annotation file | Required with `--counts-matrix` |
+| `--gene-body-bed` | None | BED12 file (plain or `.gz`) for gene body coverage, RSeQC-style | Provide a curated single-transcript-per-gene BED (e.g. RSeQC `HouseKeepingGenes.bed.gz`, MANE_Select export) to enable the gene body coverage plot |
 | `--read-len-bin-width` | 100 | Bin width for read-length histograms | Decrease for finer resolution |
 
 # Output

--- a/docs/webpages/pipeline/visualization.qmd
+++ b/docs/webpages/pipeline/visualization.qmd
@@ -20,14 +20,14 @@ without annotation.
 # Visualize N random reads
 tranquillyzer visualize \
     --num-reads 10 \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     OUTPUT_DIR
 
 # Visualize specific reads by name
 tranquillyzer visualize \
     --read-names read_001,read_002,read_003 \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     OUTPUT_DIR
 ```
@@ -40,7 +40,7 @@ Either `--num-reads` or `--read-names` must be provided.
 |---|:--:|---|
 | `OUTPUT_DIR` | required | Directory with preprocessed reads (writes to `plots/`) |
 | `--output-file` | `full_read_annots` | PDF filename prefix |
-| `--model-name` | `10x3p_sc_ont_013` | Model for inference |
+| `--model-name` | `10x3p_sc_ont_016` | Model for inference |
 | `--num-reads` | None | Number of random reads to visualize per Parquet file |
 | `--read-names` | None | Comma-separated list of specific read names |
 | `--gpu-mem` | 12 GB | GPU memory budget |

--- a/docs/webpages/quick_start.qmd
+++ b/docs/webpages/quick_start.qmd
@@ -20,14 +20,14 @@ _Tranquillyzer_ ships with pre-trained models for common 10x Genomics protocols:
 |:--|:-:|:-:|
 | Batch Size | 128 | 128 |
 | Training Fraction | 0.8 | 0.8 |
-| Vocab Size | 5 | 5 |
+| Vocab Size | 5 | 6 |
 | Embedding Dimension | 128 | 128 |
 | Conv Layers | 4 | 3 |
-| Conv Filters | 128 | 128 |
+| Conv Filters | 128 | 64 |
 | Conv Kernel Size | 25 | 25 |
-| Dilation Rates | [1, 1, 1, 1] | [1, 3, 5] |
+| Dilation Rates | [1, 1, 1, 1] | [1, 1, 1] |
 | LSTM Layers | 1 | 1 |
-| LSTM Units | 96 | 96 |
+| LSTM Units | 96 | 32 |
 | Bidirectional | True | True |
 | CRF Layer | True | True |
 | Attention Heads | 0 | 0 |
@@ -51,7 +51,7 @@ tranquillyzer preprocess \
 
 # 2. Annotate reads + correct barcodes + demultiplex (single pass)
 tranquillyzer annotate-reads \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     --threads 12 \
     --run-barcode-correction \
@@ -92,14 +92,14 @@ tranquillyzer preprocess \
 
 # 2. Annotate reads (no whitelist)
 tranquillyzer annotate-reads \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --gpu-mem 48 \
     --threads 12 \
     /path/to/output
 
 # 3. Discover cell barcodes via knee-point detection
 tranquillyzer generate-whitelist \
-    --model-name 10x3p_sc_ont_013 \
+    --model-name 10x3p_sc_ont_016 \
     --expected-cells 5000 \
     /path/to/output
 

--- a/docs/webpages/resource_requirements.qmd
+++ b/docs/webpages/resource_requirements.qmd
@@ -12,21 +12,31 @@ performance.
 The main factor is **read length**: longer reads require more GPU memory. The table below shows the longest read each GPU
 can handle. If the longest reads in your dataset are shorter than the limit listed for your GPU, you are good to go.
 
+::: {.callout-note}
+## Tentative figures — pending per-GPU benchmarking
+
+The numbers below are based on a single empirical run on 4× NVIDIA L40S using `10x3p_sc_ont_016`. The L40S entry is
+directly measured; all other entries are theoretical scalings using the model's per-token memory cost. Per-GPU
+empirical recommendations will be added as we benchmark each architecture; if you have results from your own runs,
+please open an issue.
+:::
+
 | GPU | VRAM (GB) | Max Read Length (bp) | Status |
 |---|:--:|:--:|:-:|
-| NVIDIA T4 | 16 | ~142,000 | Theoretical |
-| NVIDIA L4 | 24 | ~212,000 | Theoretical |
-| NVIDIA A10 | 24 | ~212,000 | Theoretical |
-| RTX 3090 | 24 | ~212,000 | Theoretical |
-| RTX 4090 | 24 | ~212,000 | Theoretical |
-| NVIDIA A100 | 40 | ~354,000 | Theoretical |
-| **NVIDIA L40S** | **48** | **~425,000** | **Empirically tested** |
-| NVIDIA A100 | 80 | ~708,000 | Theoretical |
-| NVIDIA H100 | 80 | ~708,000 | Theoretical |
+| NVIDIA T4 | 16 | ~323,000 | Theoretical |
+| NVIDIA L4 | 24 | ~484,000 | Theoretical |
+| NVIDIA A10 | 24 | ~484,000 | Theoretical |
+| RTX 3090 | 24 | ~484,000 | Theoretical |
+| RTX 4090 | 24 | ~484,000 | Theoretical |
+| NVIDIA A100 | 40 | ~807,000 | Theoretical |
+| **NVIDIA L40S** | **48** | **~525,000** | **Empirically tested** |
+| NVIDIA A100 | 80 | ~1,615,000 | Theoretical |
+| NVIDIA H100 | 80 | ~1,615,000 | Theoretical |
 
-: These limits assume XLA is enabled, `--vram-headroom 0.35` (the default), and the default model architecture
-(`10x3p_sc_ont_012`). **Empirically tested** means the model was directly observed to run at that read length.
-**Theoretical** values are extrapolated from the empirical measurement (see
+: These limits assume `--vram-headroom 0.35` (the default) and the architecture of
+`10x3p_sc_ont_016` (the current default model). **Empirically tested** corresponds to the largest read length directly
+observed in a production run on that GPU; the actual ceiling is likely higher. **Theoretical** values are extrapolated
+from the empirical anchor using the model's per-token memory cost (see
 [How feasibility limits are computed](#how-feasibility-limits-are-computed)).
 
 **A few things to keep in mind:**
@@ -43,16 +53,16 @@ can handle. If the longest reads in your dataset are shorter than the limit list
 You can estimate the maximum read length for any GPU using this rule of thumb:
 
 $$
-L_{\max} \approx \frac{\text{VRAM (GB)} \times 0.65}{73.4~\text{KB}}
+L_{\max} \approx \frac{\text{VRAM (GB)} \times 0.65}{32.2~\text{KB}}
 $$
 
-For example, a GPU with 32 GB of VRAM: $L_{\max} \approx \frac{32 \times 0.65}{0.0000734} \approx 283{,}000~\text{bp}$.
+For example, a GPU with 32 GB of VRAM: $L_{\max} \approx \frac{32 \times 0.65}{0.0000322} \approx 646{,}000~\text{bp}$.
 
 The 0.65 factor comes from the default `--vram-headroom` of 0.35 (only ~65% of memory is used, the rest is kept as a
-safety buffer). The 73.4 KB/bp constant is derived from empirical testing on NVIDIA L40S GPUs — see
-[Technical Details](#how-feasibility-limits-are-computed) for the full derivation.
+safety buffer). The 32.2 KB/bp constant is derived by scaling an L40S empirical measurement by the per-token memory cost
+of `10x3p_sc_ont_016` — see [Technical Details](#how-feasibility-limits-are-computed) for the full derivation.
 
-# How _Tranquillyzer_ Uses GPU
+# How Tranquillyzer Uses GPU
 
 You generally do not need to configure GPU settings manually. _Tranquillyzer_ automatically:
 
@@ -85,9 +95,9 @@ $$
 P_{\text{conv}} = \left\lfloor \frac{\max_i\bigl((k_i - 1) \times d_i\bigr)}{2} \right\rfloor
 $$
 
-For the default model (`conv_kernel_sizes = [25, 25, 25]`, `dilation_rates = [1, 3, 5]`), this works out to
-$P_{\text{conv}} = 60$. This padding ensures the model can see enough context to correctly label bases near the end of
-each read.
+For the current default model `10x3p_sc_ont_016` (`conv_kernel_sizes = [25, 25, 25]`, `dilation_rates = [1, 1, 1]`),
+this works out to $P_{\text{conv}} = 12$. This padding ensures the model can see enough context to correctly label
+bases near the end of each read.
 
 ### Chunks
 
@@ -141,14 +151,14 @@ Each term corresponds to a layer of the model:
 - **Input** (4 bytes): the encoded DNA base (stored as an integer).
 - **Embedding** ($d_e \times 4$): the learned vector representation of each base ($d_e$ = 128 by default).
 - **Conv activations** ($C_f \times 4$): outputs from the convolutional layers. $C_f$ is the total filter count across
-  all conv layers (128 filters $\times$ 3 layers = 384 for the default model).
-- **LSTM outputs** ($l_u \times d_{\text{bi}} \times 4$): outputs from the recurrent layer ($l_u$ = 96 units, $d_{\text{bi}}$ = 2 for bidirectional).
+  all conv layers (64 filters $\times$ 3 layers = 192 for the default model).
+- **LSTM outputs** ($l_u \times d_{\text{bi}} \times 4$): outputs from the recurrent layer ($l_u$ = 32 units, $d_{\text{bi}}$ = 2 for bidirectional).
 - **LSTM gates** ($l_u \times 4 \times d_{\text{bi}} \times 4$): internal memory used by the four LSTM gates
   (input, forget, cell, output).
 - **CRF / output** ($n_l \times 4$): the final prediction scores for each label ($n_l \approx$ 10 labels).
 - **Overhead** ($\alpha$ = 1.12): a 12% multiplier to account for TensorFlow's internal bookkeeping.
 
-For the default model, this works out to approximately **6,644 bytes per token** (see
+For the default model, this works out to approximately **2,916 bytes per token** (see
 [worked example](#bytes-per-token-estimation-formula)).
 
 The batch size from the memory check is then:
@@ -256,6 +266,37 @@ Try these steps in order:
   use the safer, dual-constraint approach.
 - **Increase `--target-tokens`** on high-VRAM GPUs (e.g., 1,500,000 or higher on A100/H100) to allow larger batches for
   longer reads.
+- **Raise `--max-batch-size`** above the default 8,192 on high-VRAM GPUs (e.g., 20,000 on 48 GB, up to ~32,000 on 80 GB)
+  to unlock larger batches on short-read bins. See [Tuning `--max-batch-size`](#tuning-max-batch-size) for guidelines.
+
+### Tuning `--max-batch-size`
+
+`--max-batch-size` is the per-GPU ceiling on batch size after the token-budget and memory checks have run. On
+**short-read bins**, GPU memory rarely binds and batch size is determined by either the token budget (default behavior)
+or `--max-batch-size` (when `--token-cap-above` is set). With the default `--max-batch-size = 8,192`, short bins on
+high-VRAM GPUs can leave a large portion of GPU compute idle.
+
+Raising `--max-batch-size` lets short-read bins use more of the GPU at once. The safe pattern is to combine a higher
+cap with `--token-cap-above`, so the cap only takes effect on bins below the threshold:
+
+```bash
+--max-batch-size 20000 --token-cap-above 10000
+```
+
+**Tentative starting points** (subject to per-GPU benchmarking):
+
+| VRAM | Suggested `--max-batch-size` (with `--token-cap-above 10000`) |
+|:--:|:-:|
+| 16 GB | 4,000 – 8,000 |
+| 24 GB | 8,000 – 12,000 |
+| 40–48 GB | 16,000 – 20,000 |
+| 80 GB | 24,000 – 32,000 |
+
+::: {.callout-warning}
+These are starting points derived from a single empirical run on 4× L40S (48 GB) — not exhaustive testing. If a chunk
+contains an outlier long read, an aggressive `--max-batch-size` can trigger an OOM recovery cycle that is slow.
+Per-GPU recommendations will be refined as we benchmark each architecture.
+:::
 
 ### Heterogeneous Multi-GPU Setups
 
@@ -277,58 +318,55 @@ reading — you do not need to understand these details to use _Tranquillyzer_ e
 
 ## Model Configuration Used for Estimates
 
-All estimates on this page correspond to the default **_Tranquillyzer_ CNN-BiLSTM-CRF** annotation model
-(`10x3p_sc_ont_012`) with the following architecture:
+All estimates on this page correspond to the **CNN-BiLSTM-CRF** annotation model `10x3p_sc_ont_016`, the current
+default. Its architecture is:
 
 | Parameter | Value |
 |---|:--:|
 | `embedding_dim` | 128 |
 | `conv_layers` | 3 |
-| `conv_filters` | 128 |
+| `conv_filters` | 64 |
 | `conv_kernel_sizes` | [25, 25, 25] |
-| `dilation_rates` | [1, 3, 5] |
+| `dilation_rates` | [1, 1, 1] |
 | `lstm_layers` | 1 |
-| `lstm_units` | 96 |
+| `lstm_units` | 32 |
 | `bidirectional` | TRUE |
 | `CRF` | TRUE |
 | `attention_heads` | 0 |
 
 ## How Feasibility Limits Are Computed
 
-The GPU feasibility limits in the [table above](#how-much-gpu-memory-do-you-need) are derived from a single empirical
-measurement and then scaled to other GPUs.
+The GPU feasibility limits in the [table above](#how-much-gpu-memory-do-you-need) combine an empirical anchor on the
+L40S with a theoretical scaling to other GPUs.
 
-### Empirical anchor
+### Empirical anchor (`10x3p_sc_ont_016`)
 
-> On a system with **4x NVIDIA L40S GPUs (48 GB VRAM each)** and XLA enabled, _Tranquillyzer_ (model
-`10x3p_sc_ont_012`) successfully processed reads of approximately **425 kb** at a per-GPU batch size of 1.
+> On a system with **4× NVIDIA L40S GPUs (48 GB VRAM each)**, _Tranquillyzer_ (model
+> `10x3p_sc_ont_016`) successfully processed reads up to **~525 kb** in a real annotation pipeline run. This is the
+> largest read length directly observed in that run; the actual ceiling on the L40S is likely higher.
+
+The run used `--vram-headroom 0.45`, `--target-tokens 1,100,000`, `--max-batch-size 20000`, and
+`--token-cap-above 10000`. With more aggressive settings (lower headroom, larger token budget), capacity can be pushed
+further.
 
 ### Scaling to other GPUs
 
-With the default headroom of 0.35, the usable memory on the L40S is:
+`10x3p_sc_ont_016` has roughly **44%** of the per-token memory cost of its predecessor `10x3p_sc_ont_012`
+(see [bpt table](#bytes-per-token-estimation-formula)). The 73.4 KB/bp empirical constant derived from a
+batch-size-1 measurement of `10x3p_sc_ont_012` on the L40S scales to approximately **32.2 KB/bp** for the current
+default model:
 
 $$
-U \approx 48~\text{GB} \times (1 - 0.35) \approx 31.2~\text{GB}
+L_{\max} \approx \frac{\text{VRAM} \times (1 - H)}{32.2~\text{KB}}
 $$
 
-Dividing by the maximum read length gives an effective memory cost per base:
-
-$$
-k \approx \frac{31.2~\text{GB}}{425{,}000~\text{bp}} \approx 73.4~\text{KB/bp}
-$$
-
-For any GPU, the maximum read length is then approximately:
-
-$$
-L_{\max} \approx \frac{\text{VRAM} \times (1 - H)}{k}
-$$
-
-where $H$ is the headroom fraction (default 0.35).
+where $H$ is the headroom fraction (default 0.35). This constant assumes overhead scales proportionally with theoretical
+per-token memory; direct per-GPU empirical confirmation is pending.
 
 ### Why empirical scaling rather than analytical calculation?
 
-GPU memory usage during inference is not just the model activations. It also includes TensorFlow/XLA compilation
-buffers, memory allocator fragmentation, LSTM internal state, CRF decoding workspace, and other overhead that is
+GPU memory usage during inference is not just the model activations. It also includes TensorFlow's cuDNN workspace
+allocations, memory allocator fragmentation, LSTM internal state, CRF decoding workspace, and other overhead that is
 difficult to predict analytically. Anchoring to a real measurement captures all of these factors, giving more reliable
 estimates — especially for ultra-long reads where these overheads become significant.
 
@@ -345,13 +383,13 @@ $$
 |---|---|:--:|---|
 | Input | 4 | 4 | One int32 per position |
 | Embedding | $d_e \times 4$ | 512 | Float32 embedding vector |
-| Conv | $C_f \times 4$ | 1,536 | Conv filter outputs ($C_f$ = filters $\times$ layers = 128 $\times$ 3) |
-| LSTM out | $l_u \times d_{\text{bi}} \times 4$ | 768 | Recurrent layer outputs (96 units $\times$ 2 directions) |
-| LSTM gates | $l_u \times 4 \times d_{\text{bi}} \times 4$ | 3,072 | Four LSTM gates, both directions |
+| Conv | $C_f \times 4$ | 768 | Conv filter outputs ($C_f$ = filters $\times$ layers = 64 $\times$ 3) |
+| LSTM out | $l_u \times d_{\text{bi}} \times 4$ | 256 | Recurrent layer outputs (32 units $\times$ 2 directions) |
+| LSTM gates | $l_u \times 4 \times d_{\text{bi}} \times 4$ | 1,024 | Four LSTM gates, both directions |
 | CRF/output | $n_l \times 4$ | 40 | Prediction scores for ~10 labels |
-| **Subtotal** | | **5,932** | |
+| **Subtotal** | | **2,604** | |
 | Overhead ($\alpha$ = 1.12) | | | 12% TensorFlow bookkeeping |
-| **Total bpt** | | **~6,644** | **bytes per token** |
+| **Total bpt** | | **~2,916** | **bytes per token** |
 
 ## Usable Memory at Runtime
 

--- a/docs/webpages/usage.qmd
+++ b/docs/webpages/usage.qmd
@@ -120,27 +120,24 @@ Optional Arguments
 
 - `--help`: Print help message and exit
 
-## 10x3p Models: `10x3p_sc_ont_012` vs `10x3p_sc_ont_013`
+## 10x3p Models: `10x3p_sc_ont_013` vs `10x3p_sc_ont_016`
 
 Two trained models are available for the 10x Genomics 3' single-cell ONT protocol. Both are trained on the same
 library structure and produce the same set of segment labels; they differ only in architecture.
 
 | Model | Architecture | BiLSTM | Notes |
 |---|---|:--:|---|
-| `10x3p_sc_ont_012` | CNN-BiLSTM-CRF | 1 layer, 96 units | Previous default — includes the BiLSTM for long-range context. |
-| `10x3p_sc_ont_013` | CNN-CRF (Conv + CRF) | none | **Current default.** BiLSTM removed; annotation accuracy is comparable on typical 10x3p data. |
+| `10x3p_sc_ont_013` | CNN-CRF (Conv + CRF) | none | Previous default — BiLSTM removed for faster inference and easier scaling to very long reads. |
+| `10x3p_sc_ont_016` | CNN-BiLSTM-CRF | 1 layer, 32 units | **Current default.** A small BiLSTM is restored on top of the Conv stack; preferred annotation accuracy on typical 10x3p data. |
 
-**Why `10x3p_sc_ont_013` is now the default:**
+**Why `10x3p_sc_ont_016` is now the default:**
 
-- **Faster inference and training.** Dropping the BiLSTM removes a sequential, non-parallelizable layer.
-- **Lower GPU memory footprint.** Allows larger batch sizes on the same GPU.
-- **Better scaling to very long reads.** BiLSTM memory grows with sequence length, so removing it makes multi-hundred-kb
-  reads more tractable.
-- **Comparable accuracy.** For well-structured libraries like 10x3p, where Conv layers capture local motifs and the CRF
-  enforces globally consistent labels, the BiLSTM contributes little in practice.
-
-**When to prefer `10x3p_sc_ont_012`:** if you encounter ambiguous motifs or non-standard library variants where
-long-range context might matter. Otherwise, the lighter `_013` model is recommended.
+- **Improved annotation accuracy.** The 1×32 BiLSTM adds back enough sequential context to disambiguate
+  boundary cases that the pure Conv+CRF stack of `_013` sometimes labels inconsistently.
+- **Minimal added cost.** At only 32 hidden units, the BiLSTM is much smaller than the 96-unit variant in
+  earlier models, so per-batch throughput on typical 10x3p reads stays close to the Conv-only `_013`.
+- **Drop-in replacement.** No changes to whitelists, `seq_orders.yaml`, or downstream steps — just bump
+  `--model-name`.
 
 Both models are available from the Dropbox link below and can be selected at runtime with `--model-name`.
 
@@ -188,7 +185,7 @@ reads to their respective cells (i.e., demultiplexes) in a single step. It produ
 your dataset. Tranquillyzer uses CNN-LSTM-CRF models for annotation.
 
 Model files follow the naming convention: `<model_name>.h5`, `<model_name>_lbl_bin.pkl`,
-`<model_name>_params.yaml` (e.g., `10x3p_sc_ont_013.h5`).
+`<model_name>_params.yaml` (e.g., `10x3p_sc_ont_016.h5`).
 
 Currently available trained models can be downloaded from [this  Dropbox link](https://www.dropbox.com/scl/fo/3lms8n97bnufzqa4ausv9/AGkO3EVrL1ZgctwEwTK1mEA?rlkey=47m69a6smwsisdznbwu3jvjpu&st=253al7s3&dl=0)
 and should be placed in the `models/` directory within the cloned Tranquillyzer repository.
@@ -219,7 +216,7 @@ Required Arguments
 Optional Arguments
 
 - `--output-fmt TEXT`: Output format for demultiplexed reads: `fasta` or `fastq` (default: `fasta`)
-- `--model-name TEXT:` Base model name (default: `10x3p_sc_ont_013`)
+- `--model-name TEXT:` Base model name (default: `10x3p_sc_ont_016`)
 - `--seq-order-file TEXT`: Path to the sequence orders file. If not provided, uses the default: `utils/seq_orders.yaml`
   (default: None)
 - `--chunk-size INTEGER`: Base chunk size for processing, dynamically adjusts based on read length (default: 100000)
@@ -393,7 +390,7 @@ Required Arguments
 Optional Arguments
 
 - `--output-file TEXT`: Prefix for output file name. `.pdf` will be added automatically (default: `full_read_annots`)
-- `--model-name TEXT:` Base model name (default: `10x3p_sc_ont_013`)
+- `--model-name TEXT:` Base model name (default: `10x3p_sc_ont_016`)
 - `--seq-order-file TEXT`: Path to the sequence orders file. If not provided, uses the default: `utils/seq_orders.yaml`
   (default: None)
 - `--gpu-mem TEXT`: Total memory of the GPU in gigabytes (GB). For a single GPU or multiple GPUs with the same memory,

--- a/main.py
+++ b/main.py
@@ -281,7 +281,7 @@ def visualize(
         "full_read_annots",
         help="Output PDF base name (extension [cyan].pdf[/cyan] is added automatically).",
     ),
-    model_name: str = typer.Option("10x3p_sc_ont_013", help=_HELP_MODEL_NAME),
+    model_name: str = typer.Option("10x3p_sc_ont_016", help=_HELP_MODEL_NAME),
     seq_order_file: str = typer.Option(None, help=_HELP_SEQ_ORDER_FILE),
     models_dir: str = typer.Option(None, "--models-dir", help=_HELP_MODELS_DIR),
     gpu_mem: Annotated[str, typer.Option(help=_HELP_GPU_MEM)] = None,
@@ -349,7 +349,7 @@ def visualize(
 def annotate_reads(
     output_dir: str,
     preprocess_dir: str = typer.Option(None, "--preprocess-dir", help=_HELP_PREPROCESS_DIR, rich_help_panel="General"),
-    model_name: str = typer.Option("10x3p_sc_ont_013", help=_HELP_MODEL_NAME, rich_help_panel="Model"),
+    model_name: str = typer.Option("10x3p_sc_ont_016", help=_HELP_MODEL_NAME, rich_help_panel="Model"),
     seq_order_file: str = typer.Option(None, help=_HELP_SEQ_ORDER_FILE, rich_help_panel="Model"),
     models_dir: str = typer.Option(None, "--models-dir", help=_HELP_MODELS_DIR, rich_help_panel="Model"),
     gpu_mem: Annotated[str, typer.Option(help=_HELP_GPU_MEM, rich_help_panel="GPU & Batching")] = None,
@@ -574,7 +574,7 @@ def barcode_correct(
     ),
     seq_order_file: str = typer.Option(None, help=_HELP_SEQ_ORDER_FILE, rich_help_panel="Model"),
     model_name: str = typer.Option(
-        "10x3p_sc_ont_013",
+        "10x3p_sc_ont_016",
         help="Model name used to resolve barcode column order from seq_orders.yaml.",
         rich_help_panel="Model",
     ),
@@ -662,7 +662,7 @@ def generate_whitelist(
         ...,
         help="Annotation output directory (containing annotation_chunks/ or annotation_metadata/).",
     ),
-    model_name: str = typer.Option("10x3p_sc_ont_013", help=_HELP_MODEL_NAME),
+    model_name: str = typer.Option("10x3p_sc_ont_016", help=_HELP_MODEL_NAME),
     seq_order_file: str = typer.Option(None, help=_HELP_SEQ_ORDER_FILE),
     input_file: str = typer.Option(
         None,

--- a/main.py
+++ b/main.py
@@ -822,7 +822,7 @@ def qc_metrics(
     ),
     bam: str = typer.Option(
         None,
-        help="Dup-marked BAM with CB/UB tags. Enables saturation, mapping rate, duplication, and gene body coverage (with [cyan]--gtf[/cyan]) plots.",
+        help="Dup-marked BAM with CB/UB tags. Enables saturation, mapping rate, duplication, and gene body coverage (with [cyan]--gene-body-bed[/cyan]) plots.",
         rich_help_panel="Alignment & Gene Quantification",
     ),
     counts_matrix: str = typer.Option(
@@ -832,7 +832,17 @@ def qc_metrics(
     ),
     gtf: str = typer.Option(
         None,
-        help="GTF annotation (e.g. GENCODE). Required with [cyan]--counts-matrix[/cyan]; also enables gene body coverage with [cyan]--bam[/cyan].",
+        help="GTF annotation (e.g. GENCODE). Required with [cyan]--counts-matrix[/cyan].",
+        rich_help_panel="Alignment & Gene Quantification",
+    ),
+    gene_body_bed: str = typer.Option(
+        None,
+        help=(
+            "BED12 file (plain or [cyan].gz[/cyan]) for gene body coverage, RSeQC-style.\n\n"
+            "Required to enable the gene body coverage plot; without it the plot is skipped. "
+            "Recommended sources: RSeQC HouseKeepingGenes.bed[.gz], a MANE_Select export, "
+            "or any one-transcript-per-gene BED12."
+        ),
         rich_help_panel="Alignment & Gene Quantification",
     ),
 ):
@@ -858,7 +868,7 @@ def qc_metrics(
      12) Unique UMIs per cell (requires --bam).
      13) Mapping rate per cell (requires --bam).
      14) Duplicate rate per cell (requires --bam).
-     15) Gene body coverage profile (requires --bam + --gtf).
+     15) Gene body coverage profile (requires --bam + --gene-body-bed).
      16) Genes per cell (requires --counts-matrix + --gtf).
      17) UMIs per cell (requires --counts-matrix + --gtf).
      18) Mitochondrial % per cell (requires --counts-matrix + --gtf).
@@ -894,6 +904,7 @@ def qc_metrics(
         counts_matrix=counts_matrix,
         gtf=gtf,
         threads=threads,
+        gene_body_bed=gene_body_bed,
     )
 
 

--- a/main.py
+++ b/main.py
@@ -1205,6 +1205,16 @@ def simulate_data(
         help="Maximum length of random cDNA spacer between concatenated read fragments.",
         rich_help_panel="Read Structure",
     ),
+    min_flank: int = typer.Option(
+        0,
+        help="Minimum length of random cDNA flank at each terminal end of a read.",
+        rich_help_panel="Read Structure",
+    ),
+    max_flank: int = typer.Option(
+        50,
+        help="Maximum length of random cDNA flank at each terminal end of a read. Raise above the 50bp default to cover real ONT adapter-flank lengths.",
+        rich_help_panel="Read Structure",
+    ),
 ):
     """
     Generate synthetic labeled reads for training, and serialize to PKL.
@@ -1255,6 +1265,8 @@ def simulate_data(
         max_trunc_3p,
         min_spacer,
         max_spacer,
+        min_flank,
+        max_flank,
     )
 
 
@@ -1465,6 +1477,16 @@ def assess_model(
         help="Maximum length of random cDNA spacer between concatenated read fragments.",
         rich_help_panel="Read Structure",
     ),
+    min_flank: int = typer.Option(
+        0,
+        help="Minimum length of random cDNA flank at each terminal end of a read.",
+        rich_help_panel="Read Structure",
+    ),
+    max_flank: int = typer.Option(
+        50,
+        help="Maximum length of random cDNA flank at each terminal end of a read. Raise above the 50bp default to cover real ONT adapter-flank lengths.",
+        rich_help_panel="Read Structure",
+    ),
     bin_size: int = typer.Option(
         500, help="Bin width (bp) for length-binning assessment reads.", rich_help_panel="Read Structure"
     ),
@@ -1527,6 +1549,8 @@ def assess_model(
         max_trunc_3p,
         min_spacer,
         max_spacer,
+        min_flank,
+        max_flank,
         bin_size,
         max_read_length,
         gpu_mem,

--- a/scripts/annotate_new_data.py
+++ b/scripts/annotate_new_data.py
@@ -27,7 +27,14 @@ from tensorflow.keras import backend as K
 
 from scripts.available_gpus import gpus_to_visible_devices_string
 
-os.environ["CUDA_VISIBLE_DEVICES"] = gpus_to_visible_devices_string()
+# HARDENING: only set CUDA_VISIBLE_DEVICES if we actually found GPUs.
+# Setting it to "" (which happens when gpus_to_visible_devices_string() returns
+# an empty string) masks every GPU from TF for the rest of the process, which
+# is a silent footgun when the parent of a spawn subprocess has already set the
+# correct value. See train_model_wrap.py (parent-side env priming).
+_visible = gpus_to_visible_devices_string()
+if _visible:
+    os.environ["CUDA_VISIBLE_DEVICES"] = _visible
 
 tf.config.experimental.enable_tensor_float_32_execution(False)
 tf.keras.utils.set_random_seed(1)
@@ -48,7 +55,12 @@ if available_gpus.n_gpus() > 0:
     for gpu in available_gpus.get_tensorflow_output():
         tf.config.experimental.set_memory_growth(gpu, True)
 
-tf.config.optimizer.set_jit(True)
+# HARDENING: global XLA JIT is disabled. tf2crf's Viterbi decode is not
+# XLA-compatible; fused compilation with a CRF head on TF 2.15 has produced
+# intermittent kernel miscompiles that surface as "Unexpected Event status: 1"
+# from the CUDA event manager. Models without CRF lose ~10-15% inference
+# throughput but stability is the priority here.
+# tf.config.optimizer.set_jit(True)
 
 
 @njit
@@ -250,6 +262,17 @@ def predict_with_backoff(model, build_dataset_fn, start_batch: int, min_batch: i
             last_err = e
             new_bs = max(int(min_batch), bs // 2)
             logger.warning(f"OOM at batch={bs}. Retrying with batch={new_bs}...")
+            # HARDENING: we are about to call K.clear_session() which invalidates
+            # every TF variable/kernel on GPU. Without a rebuild_model_fn, the
+            # model reference we hold will dangle — the next model.predict() would
+            # submit CUDA kernels referencing freed allocations, which is a
+            # documented trigger for "Unexpected Event status: 1" / driver
+            # corruption. Raise immediately instead of looping on a dead model.
+            if rebuild_model_fn is None:
+                raise RuntimeError(
+                    f"OOM at batch={bs} with no rebuild_model_fn provided. "
+                    f"Cannot safely recover; aborting to protect driver state."
+                ) from e
             K.clear_session()
             gc.collect()
             for dev in available_gpus.get_gpu_names_raw():
@@ -258,12 +281,16 @@ def predict_with_backoff(model, build_dataset_fn, start_batch: int, min_batch: i
                 except Exception:
                     pass
             time.sleep(1.0)
-            if rebuild_model_fn is not None:
-                try:
-                    model = rebuild_model_fn()
-                    logger.info("Model rebuilt after OOM recovery")
-                except Exception as rebuild_err:
-                    logger.error(f"Failed to rebuild model after OOM: {rebuild_err}")
+            try:
+                model = rebuild_model_fn()
+                logger.info("Model rebuilt after OOM recovery")
+            except Exception as rebuild_err:
+                # HARDENING: if rebuild fails, the old model is already stale
+                # (clear_session ran). Looping on it is unsafe — raise instead.
+                raise RuntimeError(
+                    f"OOM rebuild failed after batch={bs}: {rebuild_err}. "
+                    f"Model is stale; aborting to protect driver state."
+                ) from rebuild_err
             bs = new_bs
     raise RuntimeError("Prediction OOM/cancelled even at batch=1") from last_err
 

--- a/scripts/annotate_new_data.py
+++ b/scripts/annotate_new_data.py
@@ -407,6 +407,7 @@ def load_model_for_inference(model_path, num_labels):
     n_gpus = available_gpus.n_gpus()
     min_batch = int(n_gpus) if n_gpus > 0 else 1
     strategy = tf.distribute.MirroredStrategy() if n_gpus > 1 else None
+    available_gpus.log_gpus_in_use(strategy=strategy)
 
     conv_filters = 256
     params = load_model_params(model_path)
@@ -422,7 +423,7 @@ def model_predictions(
     parquet_file,
     chunk_start,
     chunk_size,
-    model,
+    model_state,
     model_path,
     strategy,
     params,
@@ -437,8 +438,10 @@ def model_predictions(
 ):
     """Yield per-chunk (predictions, read_names, reads, lengths, qualities) from a Parquet file.
 
-    The *model* is pre-built by the caller via :func:`load_model_for_inference`
-    and reused across bins.
+    *model_state* is a mutable dict ``{"model": <keras model>, "using_strategy":
+    <bool>}`` owned by the caller and shared across bin calls. It lets us
+    only call ``build_model`` on genuine strategy flips instead of on every
+    new bin.
     """
     total_rows = calculate_total_rows(parquet_file)
     bin_name = os.path.basename(parquet_file).replace(".parquet", "")
@@ -490,7 +493,8 @@ def model_predictions(
     def _rebuild_model():
         return build_model(model_path, conv_filters, num_labels, strategy=strategy)
 
-    using_strategy = strategy is not None
+    model = model_state["model"]
+    using_strategy = model_state["using_strategy"]
 
     for chunk_idx in range(chunk_start, num_chunks + 1):
         if callable(should_process_chunk) and not should_process_chunk(bin_name, chunk_idx):
@@ -515,6 +519,9 @@ def model_predictions(
             if not using_strategy and strategy is not None:
                 model = build_model(model_path, conv_filters, num_labels, strategy=strategy)
                 using_strategy = True
+                model_state["model"] = model
+                model_state["using_strategy"] = True
+                available_gpus.log_gpus_in_use(strategy=strategy)
             chunk_predictions, global_bs, model = annotate_new_data_parallel(
                 X_new_padded,
                 model,
@@ -522,10 +529,14 @@ def model_predictions(
                 min_batch=min_batch,
                 rebuild_model_fn=_rebuild_model,
             )
+            model_state["model"] = model  # capture any OOM-driven rebuild
         else:
             if using_strategy:
                 model = build_model(model_path, conv_filters, num_labels, strategy=None)
                 using_strategy = False
+                model_state["model"] = model
+                model_state["using_strategy"] = False
+                available_gpus.log_gpus_in_use(strategy=None)
             small_bs = max(1, min(global_bs, len(reads)))
             chunk_predictions = model.predict(X_new_padded, batch_size=small_bs, verbose=0)
 

--- a/scripts/annotate_new_data.py
+++ b/scripts/annotate_new_data.py
@@ -55,13 +55,6 @@ if available_gpus.n_gpus() > 0:
     for gpu in available_gpus.get_tensorflow_output():
         tf.config.experimental.set_memory_growth(gpu, True)
 
-# HARDENING: global XLA JIT is disabled. tf2crf's Viterbi decode is not
-# XLA-compatible; fused compilation with a CRF head on TF 2.15 has produced
-# intermittent kernel miscompiles that surface as "Unexpected Event status: 1"
-# from the CUDA event manager. Models without CRF lose ~10-15% inference
-# throughput but stability is the priority here.
-# tf.config.optimizer.set_jit(True)
-
 
 @njit
 def encode_sequence_numba(read, encoded_seq):

--- a/scripts/annotate_reads.py
+++ b/scripts/annotate_reads.py
@@ -409,7 +409,7 @@ def load_libs():
     )
     from scripts.preprocess_reads import convert_tsv_to_parquet
     from scripts.trained_models import seq_orders, get_valid_structures
-    from scripts.available_gpus import log_gpus_used
+    from scripts.available_gpus import log_gpus_detected
 
     return (
         os,
@@ -429,7 +429,7 @@ def load_libs():
         estimate_average_read_length_from_bin,
         calculate_total_rows,
         convert_tsv_to_parquet,
-        log_gpus_used,
+        log_gpus_detected,
     )
 
 

--- a/scripts/annotate_reads.py
+++ b/scripts/annotate_reads.py
@@ -152,7 +152,7 @@ def _cleanup_annotation_outputs_for_fresh_start(output_dir, checkpoint_file):
             continue
 
 
-def _combine_invalid_chunks(chunk_output_dir, output_dir, pl, chunk_size):
+def _combine_invalid_chunks(chunk_output_dir, output_dir, pl, chunk_size, model_name):
     """Combine only invalid chunk outputs into a single parquet file.
 
     Used by the whitelist-free path where valid chunks are handled separately.
@@ -161,6 +161,7 @@ def _combine_invalid_chunks(chunk_output_dir, output_dir, pl, chunk_size):
     from utils import get_version
 
     ver_col = pl.lit(get_version()).alias("tranquillyzer_version")
+    model_col = pl.lit(model_name).alias("model_name")
 
     invalid_dir = os.path.join(chunk_output_dir, "invalid_chunks")
     metadata_dir = os.path.join(output_dir, "annotation_metadata")
@@ -196,13 +197,13 @@ def _combine_invalid_chunks(chunk_output_dir, output_dir, pl, chunk_size):
 
     if pq_files:
         try:
-            pl.scan_parquet(pq_files).with_columns(ver_col).sink_parquet(
+            pl.scan_parquet(pq_files).with_columns(ver_col, model_col).sink_parquet(
                 out_path, compression="snappy", row_group_size=chunk_size
             )
         except Exception:
             logger.warning("Parallel parquet scan failed for invalid chunks, falling back to diagonal_relaxed concat.")
             pl.concat([pl.scan_parquet(f) for f in pq_files], how="diagonal_relaxed").with_columns(
-                ver_col
+                ver_col, model_col
             ).sink_parquet(out_path, compression="snappy", row_group_size=chunk_size)
         for pq_path in pq_files:
             os.remove(pq_path)
@@ -217,11 +218,13 @@ def _convert_chunk_outputs(
     run_barcode_correction,
     pl,
     chunk_size,
+    model_name,
 ):
     """Convert chunk TSV outputs to Parquet and optionally combine into final files."""
     from utils import get_version
 
     ver_col = pl.lit(get_version()).alias("tranquillyzer_version")
+    model_col = pl.lit(model_name).alias("model_name")
 
     def _sorted_chunk_files(path, suffix):
         if not os.path.isdir(path):
@@ -266,28 +269,30 @@ def _convert_chunk_outputs(
                 _write_chunk_parquets(tsv_files, out_dir)
                 all_parquets = _sorted_chunk_files(out_dir, ".parquet")
                 try:
-                    pl.scan_parquet(all_parquets).with_columns(ver_col).sink_parquet(
+                    pl.scan_parquet(all_parquets).with_columns(ver_col, model_col).sink_parquet(
                         out_path, compression="snappy", row_group_size=chunk_size
                     )
                 except Exception:
                     logger.warning("Parallel parquet scan failed, falling back to diagonal_relaxed concat.")
                     pl.concat([pl.scan_parquet(f) for f in all_parquets], how="diagonal_relaxed").with_columns(
-                        ver_col
+                        ver_col, model_col
                     ).sink_parquet(out_path, compression="snappy", row_group_size=chunk_size)
                 for tsv_path in tsv_files:
                     os.remove(tsv_path)
             elif tsv_files:
                 # Legacy: all TSV
                 try:
-                    pl.scan_csv(tsv_files, separator="\t", infer_schema_length=5000).with_columns(ver_col).sink_parquet(
-                        out_path, compression="snappy", row_group_size=chunk_size
-                    )
+                    pl.scan_csv(tsv_files, separator="\t", infer_schema_length=5000).with_columns(
+                        ver_col, model_col
+                    ).sink_parquet(out_path, compression="snappy", row_group_size=chunk_size)
                 except Exception:
                     logger.warning("TSV scan failed due to schema mismatch, falling back to diagonal_relaxed concat.")
                     pl.concat(
                         [pl.scan_csv(f, separator="\t", infer_schema_length=5000) for f in tsv_files],
                         how="diagonal_relaxed",
-                    ).with_columns(ver_col).sink_parquet(out_path, compression="snappy", row_group_size=chunk_size)
+                    ).with_columns(ver_col, model_col).sink_parquet(
+                        out_path, compression="snappy", row_group_size=chunk_size
+                    )
                 if keep_chunk_tsv_after_combine:
                     _write_chunk_parquets(tsv_files, out_dir)
                 for tsv_path in tsv_files:
@@ -295,14 +300,14 @@ def _convert_chunk_outputs(
             elif parquet_files:
                 # Parallel multi-file scan — Polars reads chunks across cores internally
                 try:
-                    pl.scan_parquet(parquet_files).with_columns(ver_col).sink_parquet(
+                    pl.scan_parquet(parquet_files).with_columns(ver_col, model_col).sink_parquet(
                         out_path, compression="snappy", row_group_size=chunk_size
                     )
                 except Exception:
                     # Fallback for schema mismatches (e.g., resumed runs with mixed formats)
                     logger.warning("Parallel parquet scan failed, falling back to diagonal_relaxed concat.")
                     pl.concat([pl.scan_parquet(f) for f in parquet_files], how="diagonal_relaxed").with_columns(
-                        ver_col
+                        ver_col, model_col
                     ).sink_parquet(out_path, compression="snappy", row_group_size=chunk_size)
 
         _combine_valid_invalid(valid_files, valid_chunk_parquets, f"{metadata_dir}/{valid_output_name}", valid_out_dir)

--- a/scripts/available_gpus.py
+++ b/scripts/available_gpus.py
@@ -5,9 +5,10 @@ First `import available_gpus` call sets up all functions within module and makes
 them available to call. All imports of available_gpus will retain the same
 values within a single run of tranquillyzer.
 
-TODO: This entire module is currently set up under the premise that all GPUs
-will available will be used. When this gets changed, this module will need
-reworked accordingly.
+Detection vs. actual usage are reported separately:
+- :func:`log_gpus_detected` reports what TensorFlow physically sees.
+- :func:`log_gpus_in_use` reports how many / which of those the current command
+  will actually run on (callers pass the resolved distribution strategy).
 """
 
 import logging
@@ -51,14 +52,33 @@ def gpus_to_visible_devices_string():
     return ",".join(map(str, range(n_gpus())))
 
 
-def log_gpus_used():
-    """Adds log message about which GPUs are used."""
-    # TODO: This may need to be updated if/when user is allowed to choose which
-    #       GPUs to run with
+def log_gpus_detected():
+    """Log how many physical GPUs TensorFlow sees. Makes no claim about usage."""
     if n_gpus() > 0:
-        logger.info(f"GPUs detected - running on {n_gpus()} GPUS (names: {', '.join(get_gpu_names_clean())})")
+        logger.info(f"GPUs detected: {n_gpus()} ({', '.join(get_gpu_names_clean())})")
     else:
-        logger.info("No GPUs detected - running in CPU-only mode")
+        logger.info("No GPUs detected")
+
+
+def log_gpus_in_use(strategy=None):
+    """Log how many GPUs the current command will actually run on.
+
+    Pass the distribution *strategy* the caller resolved (``MirroredStrategy``
+    when training/inferring across multiple GPUs, ``None`` for single-device
+    or CPU paths). The message distinguishes the multi-GPU strategy case from
+    a single-device run, and from CPU-only mode.
+    """
+    names = get_gpu_names_clean()
+    total = n_gpus()
+    if total == 0:
+        logger.info("Running in CPU-only mode")
+        return
+    if strategy is not None:
+        n = int(getattr(strategy, "num_replicas_in_sync", total))
+        used_names = names[:n] if n <= len(names) else names
+        logger.info(f"Running on {n} GPU(s) via MirroredStrategy: {', '.join(used_names)}")
+    else:
+        logger.info(f"Running on 1 of {total} detected GPU(s): {names[0]}")
 
 
 def available_gpus():

--- a/scripts/barcode_correction.py
+++ b/scripts/barcode_correction.py
@@ -101,7 +101,12 @@ def _has_usable_base_qualities(lazy_df):
 
 def _infer_barcode_columns(columns, whitelist_df, seq_order_file, model_name, seq_orders):
     """Infer barcode column names from seq_orders config or annotation/whitelist column overlap."""
-    if seq_order_file:
+    if seq_order_file or model_name:
+        if seq_order_file is None:
+            import os
+
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+            seq_order_file = os.path.join(base_dir, "..", "utils", "seq_orders.yaml")
         _, _, barcodes, _, strand = seq_orders(seq_order_file, model_name)
         if barcodes:
             return barcodes, strand

--- a/scripts/discover_barcodes.py
+++ b/scripts/discover_barcodes.py
@@ -330,7 +330,7 @@ def build_whitelist_from_discovery(canonical_tuples, barcode_columns):
     return whitelist_df, whitelist_dict
 
 
-def save_discovered_whitelist(whitelist_df, output_path):
+def save_discovered_whitelist(whitelist_df, output_path, model_name):
     """Write discovered whitelist to TSV file.
 
     Parameters
@@ -339,10 +339,12 @@ def save_discovered_whitelist(whitelist_df, output_path):
         Whitelist DataFrame from ``build_whitelist_from_discovery``.
     output_path : str
         Path to write the TSV file.
+    model_name : str
+        Model name to record in the file header.
     """
     from utils import write_tsv_with_version
 
-    write_tsv_with_version(output_path, whitelist_df.to_csv(sep="\t", index=False))
+    write_tsv_with_version(output_path, whitelist_df.to_csv(sep="\t", index=False), model_name)
     logger.info(f"Saved discovered whitelist ({len(whitelist_df)} barcodes) to {output_path}")
 
 
@@ -421,7 +423,7 @@ def plot_barcode_rank(counts, n_knee, output_path):
     logger.info(f"Saved barcode rank plot to {output_path}")
 
 
-def save_barcode_counts_tsv(counts, barcode_columns, knee_tuples, mapping, output_path):
+def save_barcode_counts_tsv(counts, barcode_columns, knee_tuples, mapping, output_path, model_name):
     """Write all observed barcode tuples with counts and discovery status to TSV.
 
     Parameters
@@ -436,6 +438,8 @@ def save_barcode_counts_tsv(counts, barcode_columns, knee_tuples, mapping, outpu
         Variant -> canonical tuple mapping from near-duplicate merging.
     output_path : str
         Path to write the TSV file.
+    model_name : str
+        Model name to record in the file header.
     """
     knee_set = set(knee_tuples)
     canonical_set = set(mapping.values()) if mapping else set()
@@ -459,7 +463,7 @@ def save_barcode_counts_tsv(counts, barcode_columns, knee_tuples, mapping, outpu
     df = pd.DataFrame(rows)
     from utils import write_tsv_with_version
 
-    write_tsv_with_version(output_path, df.to_csv(sep="\t", index=False))
+    write_tsv_with_version(output_path, df.to_csv(sep="\t", index=False), model_name)
     logger.info(f"Saved barcode counts ({len(df)} entries) to {output_path}")
 
 
@@ -467,6 +471,7 @@ def run_barcode_discovery(
     global_counts,
     barcode_columns,
     output_dir,
+    model_name,
     expected_cells=None,
     min_reads=3,
     min_cell_ratio=0.01,
@@ -488,6 +493,8 @@ def run_barcode_discovery(
         Barcode column names.
     output_dir : str
         Output directory for whitelist and stats files.
+    model_name : str
+        Model name to record in TSV artifact headers.
     expected_cells : int or None
         Optional hint for knee detection.
     min_reads : int
@@ -549,7 +556,7 @@ def run_barcode_discovery(
     whitelist_df, whitelist_dict = build_whitelist_from_discovery(canonical_tuples, barcode_columns)
 
     # Save artifacts
-    save_discovered_whitelist(whitelist_df, os.path.join(metadata_dir, "discovered_whitelist.tsv"))
+    save_discovered_whitelist(whitelist_df, os.path.join(metadata_dir, "discovered_whitelist.tsv"), model_name)
     save_discovery_stats(
         os.path.join(metadata_dir, "barcode_discovery_stats.json"),
         barcode_columns,
@@ -563,6 +570,7 @@ def run_barcode_discovery(
         knee_tuples,
         mapping,
         os.path.join(metadata_dir, "barcode_counts.tsv"),
+        model_name,
     )
 
     return whitelist_df, whitelist_dict

--- a/scripts/extract_annotated_seqs.py
+++ b/scripts/extract_annotated_seqs.py
@@ -344,9 +344,10 @@ def process_full_len_reads(data, barcodes, label_binarizer, model_path, split_co
 
     if annotations["architecture"] == "valid":
         for barcode in barcodes:
-            annotations[barcode]["Sequences"] = [
-                read[int(annotations[barcode]["Starts"][0]) : int(annotations[barcode]["Ends"][0])]
-            ]
+            if annotations[barcode]["Starts"]:
+                annotations[barcode]["Sequences"] = [
+                    read[int(annotations[barcode]["Starts"][0]) : int(annotations[barcode]["Ends"][0])]
+                ]
 
     # Compute edit distances for segments with known literal patterns (all reads, not just valid)
     if known_patterns:

--- a/scripts/qc_metrics.py
+++ b/scripts/qc_metrics.py
@@ -63,6 +63,19 @@ def _count_rows(path):
     return pl.scan_parquet(path).select(pl.len()).collect()[0, 0]
 
 
+_QC_MODEL_NAME = None
+
+
+def _set_qc_model_name(model_name):
+    """Set the model name to be written in QC artifact headers.
+
+    Called once by the wrapper before plot functions run. Used by
+    ``_write_tsv`` to emit a ``# model_name:`` header in plot-data TSVs.
+    """
+    global _QC_MODEL_NAME
+    _QC_MODEL_NAME = model_name
+
+
 def _write_tsv(tsv_dir, filename, df):
     """Write a Polars DataFrame as a TSV file into *tsv_dir*."""
     if tsv_dir is None:
@@ -73,6 +86,7 @@ def _write_tsv(tsv_dir, filename, df):
 
     with open(path, "w") as fh:
         fh.write(f"# tranquillyzer_version: {get_version()}\n")
+        fh.write(f"# model_name: {_QC_MODEL_NAME}\n")
         fh.write(df.write_csv(separator="\t"))
 
 
@@ -374,7 +388,7 @@ def _build_row_figure(row, n_cols, shared_yaxes=False):
     return combined
 
 
-def _write_html_report(path, row_figs, sample_name):
+def _write_html_report(path, row_figs, sample_name, model_name):
     """
     Combine per-row Plotly figures into a single self-contained HTML file.
     Plotly.js is loaded once via CDN; each figure renders with its own modebar.
@@ -396,14 +410,17 @@ def _write_html_report(path, row_figs, sample_name):
         )
 
     page_title = f"Tranquillyzer v{__version__} QC Report \u2014 {sample_name}"
+    subtitle = f"Model: {model_name}"
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(
             "<!DOCTYPE html><html>"
-            f"<head><meta charset='utf-8'><meta name='generator' content='tranquillyzer v{__version__}'><style>"
+            f"<head><meta charset='utf-8'><meta name='generator' content='tranquillyzer v{__version__}'>"
+            f"<meta name='tranquillyzer-model' content='{model_name}'><style>"
             "body{background:#f5f7fa;font-family:Arial,sans-serif;margin:0;padding:16px}"
-            "h1{text-align:center;font-size:18px;color:#333;margin:0 0 8px}"
+            "h1{text-align:center;font-size:18px;color:#333;margin:0 0 4px}"
+            "h2{text-align:center;font-size:13px;color:#666;font-weight:normal;margin:0 0 12px}"
             "</style></head>"
-            f"<body><h1>{page_title}</h1>"
+            f"<body><h1>{page_title}</h1><h2>{subtitle}</h2>"
         )
         for fig_html in html_figs:
             fh.write(

--- a/scripts/qc_metrics.py
+++ b/scripts/qc_metrics.py
@@ -2348,17 +2348,21 @@ def _plot_segment_lengths(valid_path, vcols, tsv_dir=None):
 
 
 def _bam_awk_prog():
-    """Return the awk program used to extract fields from SAM records."""
+    """Return the awk program used to extract fields from SAM records.
+
+    Uses three ``index($0, "\\tTAG:Z:")`` lookups + substring-to-next-tab
+    instead of iterating ``for(i=12;i<=NF;i++)``. Scans the line at most
+    three times regardless of tag count — ~3.6× faster than field-walk
+    on ONT BAMs (which carry many aux tags per record). Output schema
+    is unchanged: ``qname \\t flag \\t cb \\t umi \\t dt``.
+    """
     return (
         'BEGIN{OFS="\\t"}'
         "{"
         '  cb=""; ub=""; dt="";'
-        "  for(i=12;i<=NF;i++){"
-        "    t=substr($i,1,5);"
-        '    if(t=="CB:Z:") cb=substr($i,6);'
-        '    else if(t=="UB:Z:") ub=substr($i,6);'
-        '    else if(t=="DT:Z:") dt=substr($i,6)'
-        "  };"
+        '  i=index($0,"\\tCB:Z:"); if(i){cb=substr($0,i+6); j=index(cb,"\\t"); if(j) cb=substr(cb,1,j-1)}'
+        '  i=index($0,"\\tUB:Z:"); if(i){ub=substr($0,i+6); j=index(ub,"\\t"); if(j) ub=substr(ub,1,j-1)}'
+        '  i=index($0,"\\tDT:Z:"); if(i){dt=substr($0,i+6); j=index(dt,"\\t"); if(j) dt=substr(dt,1,j-1)}'
         "  print $1,$2,cb,ub,dt"
         "}"
     )
@@ -2424,12 +2428,20 @@ def _partition_references(bam_path, n_buckets):
     Use ``samtools idxstats`` to partition reference sequences into balanced
     buckets by read count (greedy largest-first bin packing).
 
+    Any reference whose mapped+unmapped count exceeds the per-bucket target
+    (``total // n_buckets``) is sub-split into multiple ``chrom:start-end``
+    region strings so a single huge reference (e.g. chrM at ~19% of total
+    alignments) doesn't stall one worker while others finish early. samtools
+    accepts these region strings via the BAI index, so the worker code is
+    untouched.
+
     Returns
     -------
     list[list[str]]
-        Each inner list is a group of reference names for one worker.
+        Each inner list is a group of region strings for one worker.
         A final empty list ``[]`` is appended for unmapped reads.
     """
+    import math
     import subprocess
     import shlex
 
@@ -2442,27 +2454,49 @@ def _partition_references(bam_path, n_buckets):
     if result.returncode != 0:
         raise RuntimeError(f"samtools idxstats failed: {result.stderr}")
 
-    refs = []  # (name, mapped + unmapped count)
+    raw_refs = []  # (name, length, count)
     for line in result.stdout.strip().splitlines():
         parts = line.split("\t")
         if parts[0] == "*":
             continue
+        ref_len = int(parts[1])
         count = int(parts[2]) + int(parts[3])
         if count > 0:
-            refs.append((parts[0], count))
+            raw_refs.append((parts[0], ref_len, count))
+
+    if not raw_refs:
+        return [[]]
+
+    total = sum(c for _, _, c in raw_refs)
+    target = max(1, total // n_buckets)
+
+    # Sub-split refs that exceed the per-bucket target into ceil(count/target)
+    # equally-sized coordinate windows. samtools regions are 1-based inclusive.
+    refs = []  # (region_str, count)
+    for name, ref_len, count in raw_refs:
+        if count <= target or ref_len <= 1:
+            refs.append((name, count))
+            continue
+        n_chunks = max(2, math.ceil(count / target))
+        chunk_len = max(1, math.ceil(ref_len / n_chunks))
+        synthetic = max(1, count // n_chunks)
+        for k in range(n_chunks):
+            start = k * chunk_len + 1
+            end = min((k + 1) * chunk_len, ref_len)
+            if start > ref_len:
+                break
+            refs.append((f"{name}:{start}-{end}", synthetic))
 
     # sort descending by count for greedy packing
     refs.sort(key=lambda x: x[1], reverse=True)
 
     buckets = [[] for _ in range(n_buckets)]
     bucket_sizes = [0] * n_buckets
-    for name, count in refs:
-        # put into lightest bucket
+    for region, count in refs:
         idx = bucket_sizes.index(min(bucket_sizes))
-        buckets[idx].append(name)
+        buckets[idx].append(region)
         bucket_sizes[idx] += count
 
-    # remove empty buckets, add unmapped bucket
     partitions = [b for b in buckets if b]
     partitions.append([])  # empty list signals unmapped reads
     return partitions
@@ -2502,12 +2536,22 @@ def _collect_bam_per_cell_stats(bam_path, threads=4):
 
     if threads > 1 and has_index:
         # --- parallel region-based scan ---
-        # Cap workers: too many concurrent samtools processes thrash disk I/O
-        n_workers = min(threads, 8)
+        # Split --threads between concurrent BAI random-access streams
+        # (n_workers) and per-stream samtools decompression threads
+        # (sam_threads). On networked filesystems (e.g. GPFS), 8 concurrent
+        # random-access samtools processes thrash the disk; 4 streams with
+        # 4 decompression threads each gets equivalent CPU with much less
+        # I/O contention. samtools rarely benefits beyond 4 threads, so cap
+        # there. Total CPU = n_workers * sam_threads ≤ threads.
+        n_workers = min(threads, 4)
+        sam_threads = max(1, min(4, threads // n_workers))
         partitions = _partition_references(bam_path, n_workers)
-        logger.info(f"  Parallel BAM scan: {len(partitions)} region groups across {n_workers} workers")
+        logger.info(
+            f"  Parallel BAM scan: {len(partitions)} region groups across "
+            f"{n_workers} workers (samtools -@{sam_threads} per worker)"
+        )
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
-            futures = [pool.submit(_scan_bam_regions, str(bam_path), regions, 1) for regions in partitions]
+            futures = [pool.submit(_scan_bam_regions, str(bam_path), regions, sam_threads) for regions in partitions]
             dfs = [f.result() for f in futures]
         df = pl.concat([d for d in dfs if d.height > 0], how="vertical")
     else:
@@ -3672,149 +3716,192 @@ def _resolve_chrom_mapping(gtf_chroms, bam_references):
     return mapping
 
 
-def _build_gene_percentiles(gtf_path, n_bins=100, min_mRNA_length=100):
+def _build_gene_percentiles_from_bed(bed_path, n_bins=100, min_mRNA_length=100):
     """
-    Parse GTF and build 100 percentile positions per gene (RSeQC-style).
+    Parse a BED12 file and build *n_bins* percentile positions per record (RSeQC-style).
 
-    For each gene, picks the longest transcript, collects all exonic base
-    positions (1-based genomic coordinates) in 5'→3' order, and samples
-    *n_bins* evenly-spaced percentile points.
+    Each BED12 line is treated as one transcript (RSeQC convention — no per-gene
+    auto-picking). The user is expected to supply a curated BED (e.g. RSeQC's
+    ``HouseKeepingGenes.bed``, a MANE_Select export, or any one-transcript-per-gene
+    BED12). Both plain and gzipped (``.gz`` / ``.bgz``) inputs are accepted.
+
+    BED12 columns used: chrom (0), chromStart (1, 0-based), name (3), strand (5),
+    blockCount (9), blockSizes (10, comma-separated), blockStarts (11, comma-separated
+    offsets from chromStart). Exonic base positions are emitted as 1-based to match
+    the existing pileup convention.
 
     Returns
     -------
     dict
-        ``{gene_id: (chrom, strand, [100 genomic positions])}``
+        ``{name: (chrom, strand, [n_bins genomic positions])}``. Duplicate names
+        get a counter suffix so each line is preserved independently.
     """
-    from collections import defaultdict
-    import HTSeq
+    import gzip
 
-    tx_exons = defaultdict(list)
-    tx_gene = {}
-    gtf = HTSeq.GFF_Reader(gtf_path)
-    for feat in gtf:
-        if feat.type != "exon":
-            continue
-        tid = feat.attr.get("transcript_id", "").strip()
-        gid = _strip_gene_version(feat.attr.get("gene_id", "").strip())
-        if not tid or not gid:
-            continue
-        tx_exons[tid].append((feat.iv.chrom, feat.iv.strand, feat.iv.start, feat.iv.end))
-        tx_gene[tid] = gid
-
-    # Pick longest transcript per gene
-    best_tid_by_gene = {}
-    best_len_by_gene = {}
-    for tid, exs in tx_exons.items():
-        if not exs:
-            continue
-        total_len = sum(e - s for _, _, s, e in exs)
-        gid = tx_gene.get(tid)
-        if gid is None:
-            continue
-        if gid not in best_len_by_gene or total_len > best_len_by_gene[gid]:
-            best_len_by_gene[gid] = total_len
-            best_tid_by_gene[gid] = tid
-
+    opener = gzip.open if bed_path.endswith((".gz", ".bgz")) else open
     g_percentiles = {}
-    for gid, tid in best_tid_by_gene.items():
-        exs = tx_exons[tid]
-        chrom = exs[0][0]
-        strand = exs[0][1]
-        # Sort exons by genomic position (ascending) — always, regardless of strand
-        exs_sorted = sorted(exs, key=lambda x: x[2])
-        # Collect all exonic base positions (1-based, like RSeQC) in ascending genomic order
-        gene_all_base = []
-        for _, _, start, end in exs_sorted:
-            gene_all_base.extend(range(start + 1, end + 1))
-        if len(gene_all_base) < min_mRNA_length:
-            continue
-        # Pick n_bins percentile positions (equivalent to mystat.percentile_list)
-        # Positions always in ascending genomic order; strand reversal happens after pileup
-        idx = np.linspace(0, len(gene_all_base) - 1, num=n_bins).astype(int)
-        positions = [gene_all_base[i] for i in idx]
-        g_percentiles[gid] = (chrom, strand, positions)
+    name_counts = {}
+
+    with opener(bed_path, "rt") as fh:
+        for line_no, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line or line.startswith(("#", "track", "browser")):
+                continue
+            cols = line.split("\t")
+            if len(cols) < 12:
+                logger.warning(f"  BED parse: line {line_no} has {len(cols)} columns, expected 12; skipping")
+                continue
+            try:
+                chrom = cols[0]
+                chrom_start = int(cols[1])
+                name = cols[3]
+                strand = cols[5]
+                block_count = int(cols[9])
+                block_sizes = [int(x) for x in cols[10].rstrip(",").split(",") if x]
+                block_starts = [int(x) for x in cols[11].rstrip(",").split(",") if x]
+            except (ValueError, IndexError) as e:
+                logger.warning(f"  BED parse: line {line_no} malformed ({e}); skipping")
+                continue
+
+            if len(block_sizes) != block_count or len(block_starts) != block_count:
+                logger.warning(f"  BED parse: line {line_no} blockCount mismatch; skipping")
+                continue
+
+            # Exonic positions (1-based genomic, ascending order)
+            exonic_bases = []
+            for size, offset in zip(block_sizes, block_starts):
+                exon_start_1b = chrom_start + offset + 1  # BED is 0-based half-open
+                exonic_bases.extend(range(exon_start_1b, exon_start_1b + size))
+
+            if len(exonic_bases) < min_mRNA_length:
+                continue
+
+            idx = np.linspace(0, len(exonic_bases) - 1, num=n_bins).astype(int)
+            positions = [exonic_bases[i] for i in idx]
+
+            # Disambiguate duplicate names (RSeQC keeps every line independent)
+            count = name_counts.get(name, 0)
+            key = name if count == 0 else f"{name}__{count}"
+            name_counts[name] = count + 1
+
+            g_percentiles[key] = (chrom, strand, positions)
 
     return g_percentiles
 
 
 def _process_chromosome_pileup(args):
     """
-    Worker: RSeQC-style pileup coverage for genes on one chromosome.
+    Worker: single-pass RSeQC-equivalent coverage on one chromosome.
 
-    For each gene, iterates the pileup at the 100 percentile positions and
-    counts reads (skipping deletions, qcfail, secondary, unmapped, duplicate).
-    Returns a dict mapping percentile index → summed coverage.
+    Iterates primary alignments on the chromosome ONCE via ``bam.fetch``, uses a
+    sweep-line over BED records sorted by start to find which records each read
+    overlaps, and increments per-record percentile bins via ``read.get_blocks()``
+    (which correctly skips intronic ``N`` and deletion ``D`` CIGAR gaps). Same
+    per-read filters as RSeQC's pileup-based loop (qcfail / secondary / unmapped
+    / duplicate). Output matches a ``samtools pileup`` with unbounded
+    ``max_depth`` — pysam's default ``max_depth=8000`` silently caps pileup
+    coverage at very deep positions, which RSeQC inherits; this implementation
+    has no such cap.
+
+    Returns an ndarray of shape (n_bins,) with the chromosome's contribution to
+    the aggregate coverage profile, after applying ``[::-1]`` reversal for ``-``
+    strand records.
     """
     import pysam
-    import collections
+    from bisect import bisect_left, bisect_right
 
-    chrom, bam_path, genes_on_chrom = args
-    aggregated_cvg = collections.defaultdict(int)
+    chrom, bam_path, genes_on_chrom, n_bins = args
 
     bam = pysam.AlignmentFile(bam_path, "rb")
-    # Check chromosome exists in BAM
-    try:
-        bam.pileup(chrom, 1, 2)
-    except Exception:
+    if chrom not in bam.references or not genes_on_chrom:
         bam.close()
-        return dict(aggregated_cvg)
+        return np.zeros(n_bins, dtype=np.int64)
 
-    for _gid, strand, positions in genes_on_chrom:
-        coverage = {pos: 0 for pos in positions}
-        chrom_start = min(positions) - 1
-        if chrom_start < 0:
-            chrom_start = 0
-        chrom_end = max(positions)
-        pos_set = set(positions)
+    n_recs = len(genes_on_chrom)
+    pos_lists = [g[2] for g in genes_on_chrom]  # ascending genomic, 1-based
+    strands = [g[1] for g in genes_on_chrom]
+    cov_arrays = [np.zeros(n_bins, dtype=np.int64) for _ in range(n_recs)]
+    rec_min = [p[0] for p in pos_lists]  # 1-based
+    rec_max = [p[-1] for p in pos_lists]  # 1-based
 
-        for pileupcolumn in bam.pileup(chrom, chrom_start, chrom_end, truncate=True):
-            ref_pos = pileupcolumn.pos + 1  # 1-based
-            if ref_pos not in pos_set:
-                continue
-            if pileupcolumn.n == 0:
-                coverage[ref_pos] = 0
-                continue
-            cover_read = 0
-            for pileupread in pileupcolumn.pileups:
-                if pileupread.is_del:
-                    continue
-                if pileupread.alignment.is_qcfail:
-                    continue
-                if pileupread.alignment.is_secondary:
-                    continue
-                if pileupread.alignment.is_unmapped:
-                    continue
-                if pileupread.alignment.is_duplicate:
-                    continue
-                cover_read += 1
-            coverage[ref_pos] = cover_read
+    # Order indices by ascending start so we can sweep
+    order = sorted(range(n_recs), key=lambda i: rec_min[i])
+    fetch_start = max(0, min(rec_min) - 1)
+    fetch_end = max(rec_max)
 
-        tmp = [coverage[k] for k in sorted(coverage)]
-        if strand == "-":
-            tmp = tmp[::-1]
-        for i in range(len(tmp)):
-            aggregated_cvg[i] += tmp[i]
+    next_add = 0
+    active = []
+
+    for read in bam.fetch(chrom, fetch_start, fetch_end):
+        if read.is_unmapped or read.is_qcfail or read.is_secondary or read.is_duplicate:
+            continue
+
+        r_start = read.reference_start  # 0-based inclusive
+        r_end = read.reference_end  # 0-based exclusive (= last covered 1-based pos)
+
+        # Add records starting at or before r_end (earliest possible overlap)
+        while next_add < n_recs and rec_min[order[next_add]] <= r_end:
+            active.append(order[next_add])
+            next_add += 1
+
+        # Drop records whose last percentile position is before this read starts
+        if active:
+            r_start_1b = r_start + 1
+            active = [i for i in active if rec_max[i] >= r_start_1b]
+
+        if not active:
+            continue
+
+        blocks = read.get_blocks()
+        if not blocks:
+            continue
+
+        for i in active:
+            pos_arr = pos_lists[i]
+            cov = cov_arrays[i]
+            for bs, be in blocks:
+                # Block is 0-based half-open; positions in pos_arr are 1-based.
+                # Covered 1-based positions: [bs+1, be]
+                lo = bisect_left(pos_arr, bs + 1)
+                hi = bisect_right(pos_arr, be)
+                if hi > lo:
+                    cov[lo:hi] += 1
 
     bam.close()
-    return dict(aggregated_cvg)
+
+    # Apply per-record strand reversal and accumulate into a single chromosome vector
+    chrom_total = np.zeros(n_bins, dtype=np.int64)
+    for i in range(n_recs):
+        cov = cov_arrays[i]
+        if strands[i] == "-":
+            chrom_total += cov[::-1]
+        else:
+            chrom_total += cov
+
+    return chrom_total
 
 
-def _compute_gene_body_coverage(bam_path, gtf_path, n_bins=100, threads=4):
+def _compute_gene_body_coverage(bam_path, *, bed_path, n_bins=100, threads=4):
     """
-    Compute gene body coverage profile from a BAM and GTF (RSeQC-style).
+    Compute gene body coverage profile from a BAM and a curated BED12 (RSeQC-style).
 
-    For each gene, samples coverage at 100 percentile positions via pileup
-    and sums across all genes.  Parallelized per chromosome.
+    For each BED12 record, samples coverage at *n_bins* percentile positions via
+    pileup and sums across all records. Parallelized per chromosome. Behaves
+    exactly like RSeQC's ``geneBody_coverage.py`` — no per-read strand filter.
 
     Returns
     -------
     dict or None
         ``{"aggregate": ndarray(n_bins,), "n_models": int}``
-        None if insufficient data.
+        None if insufficient data or *bed_path* is not provided.
     """
     import pysam
     from collections import defaultdict
     from multiprocessing import Pool
+
+    if bed_path is None:
+        logger.warning("Gene body coverage skipped: no --gene-body-bed provided.")
+        return None
 
     logger.info("Computing gene body coverage (RSeQC-style pileup) ...")
 
@@ -3824,15 +3911,15 @@ def _compute_gene_body_coverage(bam_path, gtf_path, n_bins=100, threads=4):
         bam.close()
         return None
 
-    logger.info("  Parsing GTF and building percentile positions ...")
-    g_percentiles = _build_gene_percentiles(gtf_path, n_bins=n_bins)
+    logger.info(f"  Parsing BED12 and building percentile positions: {bed_path}")
+    g_percentiles = _build_gene_percentiles_from_bed(bed_path, n_bins=n_bins)
 
     if not g_percentiles:
-        logger.warning("Gene body coverage skipped: no valid gene models found.")
+        logger.warning("Gene body coverage skipped: no valid records found in BED.")
         bam.close()
         return None
 
-    logger.info(f"  {len(g_percentiles):,} genes with exonic length >= 100 bp")
+    logger.info(f"  {len(g_percentiles):,} BED records with exonic length >= 100 bp")
 
     # Group genes by chromosome, filter to chromosomes present in BAM
     bam_refs = set(bam.references)
@@ -3843,39 +3930,43 @@ def _compute_gene_body_coverage(bam_path, gtf_path, n_bins=100, threads=4):
             genes_by_chrom[chrom].append((gid, strand, positions))
 
     if not genes_by_chrom:
-        logger.warning("Gene body coverage skipped: no overlapping chromosomes between BAM and GTF.")
+        logger.warning("Gene body coverage skipped: no overlapping chromosomes between BAM and BED.")
         return None
 
     logger.info(f"  Processing {len(genes_by_chrom)} chromosomes ...")
     n_workers = min(threads, len(genes_by_chrom))
-    args = [(chrom, bam_path, gene_list) for chrom, gene_list in genes_by_chrom.items()]
+    # Schedule biggest chromosomes first so workers don't idle while a single
+    # large chromosome (chr1, chr2) finishes.
+    args = sorted(
+        ((chrom, bam_path, gene_list, n_bins) for chrom, gene_list in genes_by_chrom.items()),
+        key=lambda x: -len(x[2]),
+    )
 
     with Pool(n_workers) as pool:
-        per_chrom = pool.map(_process_chromosome_pileup, args)
+        per_chrom = pool.map(_process_chromosome_pileup, args, chunksize=1)
 
-    # Aggregate across chromosomes
     total_cvg = np.zeros(n_bins, dtype=np.float64)
-    for cvg_dict in per_chrom:
-        for i, v in cvg_dict.items():
-            total_cvg[i] += v
+    for chrom_cvg in per_chrom:
+        total_cvg += chrom_cvg
 
     n_models = sum(len(gl) for gl in genes_by_chrom.values())
-    logger.info(f"  Gene body coverage computed over {n_models:,} genes")
+    logger.info(f"  Gene body coverage computed over {n_models:,} BED records")
     return {"aggregate": total_cvg, "n_models": n_models}
 
 
-def _plot_gene_body_coverage(bam_path, gtf_path, n_bins=100, tsv_dir=None, threads=4):
+def _plot_gene_body_coverage(bam_path, *, bed_path=None, n_bins=100, tsv_dir=None, threads=4):
     """
     RSeQC-style gene body coverage plot.
 
-    Shows a single aggregate coverage line for both bulk and single-cell modes
-    (gene body coverage is a library-level metric).
+    Consumes a curated BED12 (one transcript per line, RSeQC convention).
+    Returns ``None`` when *bed_path* is not provided so the caller drops the
+    plot from the report.
 
     Returns ``(title, fig, caption, caption_y)`` or ``None``.
     """
     result = _compute_gene_body_coverage(
         bam_path,
-        gtf_path=gtf_path,
+        bed_path=bed_path,
         n_bins=n_bins,
         threads=threads,
     )
@@ -3925,10 +4016,10 @@ def _plot_gene_body_coverage(bam_path, gtf_path, n_bins=100, tsv_dir=None, threa
     # ── caption ─────────────────────────────────────────────────────────────
     n_models = result["n_models"]
     caption = (
-        f"Transcript body coverage across {n_models:,} expressed genes, using one "
-        "representative transcript per gene. "
+        f"Transcript body coverage across {n_models:,} BED12 records from the user-supplied "
+        f"<code>--gene-body-bed</code> ({os.path.basename(bed_path)}). "
         "Coverage is sampled at 100 evenly-spaced percentile positions along each "
-        "transcript body (RSeQC-style) and summed across all transcripts. "
+        "transcript body (RSeQC-style) and summed across all records. "
         "A flat profile indicates uniform full-length coverage; "
         "a 3' or 5' skew suggests incomplete capture or degradation."
     )

--- a/scripts/simulate_training_data.py
+++ b/scripts/simulate_training_data.py
@@ -55,7 +55,14 @@ def introduce_errors_with_labels_context(
 ############## generate segments ##############
 
 
-def generate_segment(segment_type, segment_pattern, length_range, transcriptome_records, spacer_range=(0, 50)):
+def generate_segment(
+    segment_type,
+    segment_pattern,
+    length_range,
+    transcriptome_records,
+    spacer_range=(0, 50),
+    flank_range=(0, 50),
+):
     """Generate a random DNA segment matching a pattern specification."""
     if re.match(r"N\d+", segment_pattern):
         length = int(segment_pattern[1:])
@@ -75,9 +82,9 @@ def generate_segment(segment_type, segment_pattern, length_range, transcriptome_
         )
         sequence = fragment
         label = ["cDNA"] * len(sequence)
-    elif segment_pattern == "RN" and segment_type == "cDNA":
-        length = np.random.randint(spacer_range[0], spacer_range[1] + 1)
-        length = min(length, 50)
+    elif segment_pattern in ("RN", "RN_SPACER", "RN_FLANK") and segment_type == "cDNA":
+        lo, hi = flank_range if segment_pattern == "RN_FLANK" else spacer_range
+        length = np.random.randint(lo, hi + 1)
         if length == 0:
             return "", []
         if transcriptome_records:
@@ -100,11 +107,20 @@ def generate_segment(segment_type, segment_pattern, length_range, transcriptome_
 ############## generate valid read ##############
 
 
-def generate_valid_read(segments_order, segments_patterns, length_range, transcriptome_records, spacer_range=(0, 50)):
+def generate_valid_read(
+    segments_order,
+    segments_patterns,
+    length_range,
+    transcriptome_records,
+    spacer_range=(0, 50),
+    flank_range=(0, 50),
+):
     """Assemble a full synthetic read from segment patterns and structure order."""
     read_segments, label_segments = [], []
     for seg_type, seg_pattern in zip(segments_order, segments_patterns):
-        s, labs = generate_segment(seg_type, seg_pattern, length_range, transcriptome_records, spacer_range)
+        s, labs = generate_segment(
+            seg_type, seg_pattern, length_range, transcriptome_records, spacer_range, flank_range
+        )
         read_segments.append(s)
         label_segments.append(labs)
     return "".join(read_segments), [lbl for seg_lbls in label_segments for lbl in seg_lbls]
@@ -139,7 +155,7 @@ def _rc_single_pattern(pattern):
     """Reverse-complement a single element's pattern based on its type."""
     if pattern in ("A", "T"):
         return "T" if pattern == "A" else "A"
-    elif re.match(r"N\d+", pattern) or pattern in ("NN", "RN"):
+    elif re.match(r"N\d+", pattern) or pattern in ("NN", "RN", "RN_SPACER", "RN_FLANK"):
         return pattern
     else:
         return _rc_pattern_str(pattern)
@@ -150,7 +166,7 @@ def _reverse_single_pattern(pattern):
     if pattern in ("A", "T"):
         # Poly patterns unchanged when just reversed
         return pattern
-    elif re.match(r"N\d+", pattern) or pattern in ("NN", "RN"):
+    elif re.match(r"N\d+", pattern) or pattern in ("NN", "RN", "RN_SPACER", "RN_FLANK"):
         return pattern
     else:
         # Literal adapter — reverse the string only (no complement)
@@ -176,7 +192,9 @@ def _transform_pattern(pattern, from_state, to_state):
         # we need to undo the complement: apply complement without reversing.
         return (
             "".join(_RC_COMPLEMENT.get(b, b) for b in pattern)
-            if not (pattern in ("A", "T") or re.match(r"N\d+", pattern) or pattern in ("NN", "RN"))
+            if not (
+                pattern in ("A", "T") or re.match(r"N\d+", pattern) or pattern in ("NN", "RN", "RN_SPACER", "RN_FLANK")
+            )
             else pattern
         )
     elif from_state == "reverse" and to_state == "fwd":
@@ -228,18 +246,21 @@ def _build_structure_order_and_patterns(struct):
     rc_elements = struct.get("rc_elements", {})
 
     if repeat > 1:
-        # Concatenate: repeat the core with cDNA flanks between copies
+        # Concatenate: repeat the core with cDNA flanks between copies.
+        # First and last RN are terminal flanks (RN_FLANK); interior RN between
+        # fragments are chimeric-junction spacers (RN_SPACER).
         full_order = ["cDNA"]
-        full_patterns = ["RN"]
+        full_patterns = ["RN_FLANK"]
         for i in range(repeat):
             frag_order, frag_patterns = _build_fragment(order, patterns, rc_pattern[i], rc_elements)
+            is_last = i == repeat - 1
             full_order.extend(frag_order + ["cDNA"])
-            full_patterns.extend(frag_patterns + ["RN"])
+            full_patterns.extend(frag_patterns + ["RN_FLANK" if is_last else "RN_SPACER"])
     else:
-        # Single structure flanked with random cDNA
+        # Single structure flanked with random cDNA (both ends are terminal flanks)
         frag_order, frag_patterns = _build_fragment(order, patterns, rc_pattern[0], rc_elements)
         full_order = ["cDNA"] + frag_order + ["cDNA"]
-        full_patterns = ["RN"] + frag_patterns + ["RN"]
+        full_patterns = ["RN_FLANK"] + frag_patterns + ["RN_FLANK"]
 
     return full_order, full_patterns
 
@@ -273,6 +294,8 @@ def simulate_dynamic_batch_complete(
     max_trunc_3p=0,
     min_spacer=0,
     max_spacer=50,
+    min_flank=0,
+    max_flank=50,
 ):
     """Simulate a batch of synthetic reads with dynamic length and error profiles."""
     reads, labels, expected_fragments = [], [], []
@@ -285,7 +308,12 @@ def simulate_dynamic_batch_complete(
 
         struct_length_range = struct.get("length_range", length_range)
         sequence, label = generate_valid_read(
-            full_order, full_patterns, struct_length_range, transcriptome_records, spacer_range=(min_spacer, max_spacer)
+            full_order,
+            full_patterns,
+            struct_length_range,
+            transcriptome_records,
+            spacer_range=(min_spacer, max_spacer),
+            flank_range=(min_flank, max_flank),
         )
 
         sequence, label = _maybe_truncate(sequence, label, max_trunc_5p, max_trunc_3p)
@@ -320,7 +348,7 @@ def simulate_and_write_fasta(args):
 
     Args tuple: (num_reads, length_range, mismatch_rate, insertion_rate, deletion_rate,
                  polyT_error_rate, max_insertions, training_structures, transcriptome_records,
-                 rc, max_trunc_5p, max_trunc_3p, min_spacer, max_spacer,
+                 rc, max_trunc_5p, max_trunc_3p, min_spacer, max_spacer, min_flank, max_flank,
                  fasta_path, start_idx)
     """
     *sim_args, fasta_path, start_idx = args
@@ -340,6 +368,8 @@ def simulate_and_write_fasta(args):
         max_trunc_3p,
         min_spacer,
         max_spacer,
+        min_flank,
+        max_flank,
     ) = sim_args
 
     labels, expected_fragments, structure_names = [], [], []
@@ -360,6 +390,7 @@ def simulate_and_write_fasta(args):
                 struct_length_range,
                 transcriptome_records,
                 spacer_range=(min_spacer, max_spacer),
+                flank_range=(min_flank, max_flank),
             )
             sequence, label = _maybe_truncate(sequence, label, max_trunc_5p, max_trunc_3p)
 
@@ -407,6 +438,8 @@ def generate_training_reads(
     max_trunc_3p=0,
     min_spacer=0,
     max_spacer=50,
+    min_flank=0,
+    max_flank=50,
 ):
     """Generate a full set of synthetic training reads and labels."""
     # Convert BioPython SeqRecords to plain strings for fast pickling across workers
@@ -434,6 +467,8 @@ def generate_training_reads(
             max_trunc_3p,
             min_spacer,
             max_spacer,
+            min_flank,
+            max_flank,
         )
         for chunk_size in chunks
     ]

--- a/scripts/split_bam_file.py
+++ b/scripts/split_bam_file.py
@@ -410,7 +410,6 @@ def split_bam_file(
         merge_threads=merge_threads,
     )
 
-    t_all = time.time()
     logger.info("Starting split_bam")
     logger.info("Input: %s", input_bam)
     logger.info("Out dir: %s", out_dir)
@@ -551,5 +550,3 @@ def split_bam_file(
     else:
         logger.info("Removing temp dir: %s", tmp_dir)
         shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    logger.info("Finished split_bam in %.1fs", time.time() - t_all)

--- a/tests/10x3p/test_pipeline.py
+++ b/tests/10x3p/test_pipeline.py
@@ -10,6 +10,7 @@ SIM_DIR = Path("tests/10x3p")
 BARCODES = Path("tests/10x3p/barcodes.tsv")
 REF_FASTA = Path("tests/references/hg38_gencode_chr21.fa")
 REF_GTF = Path("tests/references/hg38_gencode_chr21.gtf")
+BED12 = Path("tests/references/hg38.HouseKeepingGenes.bed.gz")
 transcriptome = Path("tests/references/")
 MODELS_DIR = Path("models")
 THREADS = 1
@@ -271,6 +272,8 @@ def test_qc_metrics_with_bam():
             f"{OUT_DIR}/featurecounts_out/counts_matrix.tsv",
             "--gtf",
             REF_GTF,
+            "--gene-body-bed",
+            BED12,
             "--threads",
             THREADS,
         ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,8 +17,9 @@ def get_version() -> str:
             return "unknown"
 
 
-def write_tsv_with_version(path, content):
-    """Write a TSV/CSV string to a file with a version comment header."""
+def write_tsv_with_version(path, content, model_name):
+    """Write a TSV/CSV string to a file with version and model_name comment headers."""
     with open(path, "w") as fh:
         fh.write(f"# tranquillyzer_version: {get_version()}\n")
+        fh.write(f"# model_name: {model_name}\n")
         fh.write(content)

--- a/utils/seq_orders.yaml
+++ b/utils/seq_orders.yaml
@@ -235,7 +235,7 @@ libraries:
     training_structures:
       full_read:
         order: [5p, CBC, UMI, polyT, cDNA, 3p]
-        proportion: 0.50
+        proportion: 0.60
       concat_fwd_rev:
         order: [5p, CBC, UMI, polyT, cDNA, 3p]
         repeat: 2
@@ -251,16 +251,16 @@ libraries:
         repeat: 2
         rc_pattern: [rev, fwd]
         proportion: 0.10
-      concat_fwd_reverse:
-        order: [5p, CBC, UMI, polyT, cDNA, 3p]
-        repeat: 2
-        rc_pattern: [fwd, reverse]
-        proportion: 0.05
-      concat_reverse_fwd:
-        order: [5p, CBC, UMI, polyT, cDNA, 3p]
-        repeat: 2
-        rc_pattern: [reverse, fwd]
-        proportion: 0.05
+      # concat_fwd_reverse:
+      #   order: [5p, CBC, UMI, polyT, cDNA, 3p]
+      #   repeat: 2
+      #   rc_pattern: [fwd, reverse]
+      #   proportion: 0.05
+      # concat_reverse_fwd:
+      #   order: [5p, CBC, UMI, polyT, cDNA, 3p]
+      #   repeat: 2
+      #   rc_pattern: [reverse, fwd]
+      #   proportion: 0.05
       hairpin_type:
         order: [5p, CBC, UMI, polyT, cDNA, polyT:rev, UMI, CBC, 5p:rev]
         proportion: 0.10
@@ -307,6 +307,9 @@ models:
     library: 10x3p_sc_ont
 
   10x3p_sc_ont_013:
+    library: 10x3p_sc_ont
+
+  10x3p_sc_ont_016:
     library: 10x3p_sc_ont
 
   template_model:

--- a/utils/training_params.yaml
+++ b/utils/training_params.yaml
@@ -77,3 +77,22 @@ template_model:
   regularization: 0.01
   learning_rate: 0.001
   epochs: 5
+
+10x3p_sc_ont_016:
+  batch_size: 128
+  train_fraction: 0.8
+  vocab_size: 6
+  embedding_dim: 128
+  conv_layers: 3
+  conv_filters: [64, 64, 64]
+  conv_kernel_sizes: [25, 25, 25]
+  dilation_rates: [1, 1, 1]
+  lstm_layers: 1
+  lstm_units: [32]
+  bidirectional: true
+  crf_layer: true
+  attention_heads: 0
+  dropout_rate: 0.35
+  regularization: 0.01
+  learning_rate: 0.001
+  epochs: 5

--- a/wrappers/align_wrap.py
+++ b/wrappers/align_wrap.py
@@ -40,7 +40,9 @@ def align_wrap(input_dir, ref, output_dir, preset, filt_flag, mapq, threads, add
     subprocess.run(f"samtools index -@ {threads} {output_bam}", shell=True, check=True)
     logger.info("Indexing complete")
 
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss  # Linux gives KB
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage during alignment: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -86,6 +86,8 @@ def annotate_reads_wrap(
     if not os.path.isdir(models_dir):
         raise FileNotFoundError(f"Model directory not found: {models_dir}")
 
+    logger.info(f"Using model: {model_name} (models_dir: {models_dir})")
+
     utils_dir = os.path.join(base_dir, "utils")
     utils_dir = os.path.abspath(utils_dir)
 
@@ -497,6 +499,7 @@ def annotate_reads_wrap(
             run_barcode_correction,
             pl,
             chunk_size,
+            model_name,
         )
 
     if run_demux:

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -524,7 +524,9 @@ def annotate_reads_wrap(
         if os.path.isdir(chunk_output_dir):
             shutil.rmtree(chunk_output_dir, ignore_errors=True)
 
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss  # Linux gives KB
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage during annotation pipeline: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -410,14 +410,34 @@ def annotate_reads_wrap(
             if queued_chunks == 0:
                 logger.info("No pending chunks found. Dataset is already annotated.")
     except Exception as e:
-        # Wind down queues, close workers when done, print error and exit
+        # HARDENING: force-terminate workers with a bounded timeline rather
+        # than worker.join() with no timeout. If a worker is stuck in a CUDA
+        # or NCCL call, an unbounded join hangs until SLURM's cgroup manager
+        # SIGKILLs the whole job. SIGKILL mid-NCCL-collective is a classic
+        # way to leave the NCCL ring / driver state corrupt across jobs on
+        # the same node. Bounded shutdown keeps the driver clean.
         for _ in range(threads):
             task_queue.put(None)
 
         _empty_results_queue(result_queue, workers)
+
         for worker in workers:
-            worker.join()
-            worker.close()
+            worker.join(timeout=5)
+        for worker in workers:
+            if worker.is_alive():
+                logger.warning(f"Worker {worker.pid} still alive after 5s — sending SIGTERM")
+                worker.terminate()
+                worker.join(timeout=2)
+        for worker in workers:
+            if worker.is_alive():
+                logger.error(f"Worker {worker.pid} still alive after SIGTERM — sending SIGKILL")
+                worker.kill()
+                worker.join(timeout=2)
+        for worker in workers:
+            try:
+                worker.close()
+            except ValueError:
+                pass  # Process handle still open; safe to ignore in this fallback path.
 
         logger.error(
             f"Error found while annotating: {e}. Resume from the last checkpoint by re-running with resume enabled. Exiting!"

--- a/wrappers/annotate_reads_wrap.py
+++ b/wrappers/annotate_reads_wrap.py
@@ -69,13 +69,14 @@ def annotate_reads_wrap(
         estimate_average_read_length_from_bin,
         calculate_total_rows,
         convert_tsv_to_parquet,
-        log_gpus_used,
+        log_gpus_detected,
     ) = load_libs()
 
     start = time.time()
 
-    # Let user know whether they're running on CPU only or GPU (provided handles if so)
-    log_gpus_used()
+    # Report physical GPU detection up front; actual in-use count is logged
+    # later from inside load_model_for_inference once the strategy is resolved.
+    log_gpus_detected()
 
     # Read / create / prepare input files and directories
     base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -341,6 +342,12 @@ def annotate_reads_wrap(
     if min_batch_size < min_batch_from_model:
         min_batch_size = min_batch_from_model
 
+    # Shared mutable state so model_predictions only rebuilds on genuine
+    # strategy flips, even across bins. Without this, every bin entered
+    # `model_predictions` with the original MirroredStrategy model and
+    # rebuilt it back to single-device from scratch on every small bin.
+    model_state = {"model": model, "using_strategy": strategy is not None}
+
     task_queue = mp.Queue(maxsize=max_queue_size)
     result_queue = mp.Queue()
     count = mp.Value("i", 0)
@@ -394,7 +401,7 @@ def annotate_reads_wrap(
                     parquet_file,
                     chunk_start_local,
                     chunk_size,
-                    model,
+                    model_state,
                     model_path,
                     strategy,
                     params,

--- a/wrappers/barcode_correction_wrap.py
+++ b/wrappers/barcode_correction_wrap.py
@@ -255,6 +255,8 @@ def barcode_correction_wrap(
     )
     from scripts.trained_models import seq_orders
 
+    logger.info(f"Using model: {model_name} (seq_orders: {seq_order_file})")
+
     os.makedirs(output_dir, exist_ok=True)
 
     multi_file_input = isinstance(input_file, list)
@@ -635,7 +637,8 @@ def barcode_correction_wrap(
         from utils import get_version
 
         pl.scan_csv(chunk_paths, separator="\t", infer_schema_length=5000).with_columns(
-            pl.lit(get_version()).alias("tranquillyzer_version")
+            pl.lit(get_version()).alias("tranquillyzer_version"),
+            pl.lit(model_name).alias("model_name"),
         ).sink_parquet(corrected_parquet_tmp, compression="snappy")
 
     # Cleanup

--- a/wrappers/barcode_correction_wrap.py
+++ b/wrappers/barcode_correction_wrap.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import queue
+import resource
 import shutil
 import threading
+import time
 
 import pandas as pd
 
@@ -257,6 +259,7 @@ def barcode_correction_wrap(
 
     logger.info(f"Using model: {model_name} (seq_orders: {seq_order_file})")
 
+    start = time.time()
     os.makedirs(output_dir, exist_ok=True)
 
     multi_file_input = isinstance(input_file, list)
@@ -661,3 +664,10 @@ def barcode_correction_wrap(
         os.remove(legacy_tsv)
 
     logger.info(f"Wrote corrected annotations to {corrected_parquet}")
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/dedup_wrap.py
+++ b/wrappers/dedup_wrap.py
@@ -58,7 +58,9 @@ def dedup_wrap(input_dir, lv_threshold, stranded, per_cell, threads):
             os.remove(stale_path)
             logger.info(f"Removed intermediate file: {stale_path}")
 
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss  # Linux gives KB
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/demux_wrap.py
+++ b/wrappers/demux_wrap.py
@@ -11,6 +11,8 @@ def demux_wrap(
 ):
     """Export demultiplexed reads to FASTA/FASTQ from annotation files."""
     import os
+    import time
+    import resource
 
     from scripts.export_demux import (
         _load_df,
@@ -20,6 +22,8 @@ def demux_wrap(
         _write_from_demux_columns,
         _write_bulk_from_annotations,
     )
+
+    start = time.time()
 
     if input_file is None:
         metadata_dir = f"{input_dir}/annotation_metadata"
@@ -68,3 +72,10 @@ def demux_wrap(
 
     _gzip_file(demuxed_path)
     _gzip_file(ambiguous_path)
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/evaluate_model_wrap.py
+++ b/wrappers/evaluate_model_wrap.py
@@ -24,6 +24,8 @@ def evaluate_model_wrap(
     max_trunc_3p,
     min_spacer,
     max_spacer,
+    min_flank,
+    max_flank,
     bin_size,
     max_read_length,
     gpu_mem,
@@ -106,15 +108,15 @@ def evaluate_model_wrap(
             for pat in s["patterns"]:
                 if re.match(r"N\d+", pat):
                     fixed_per_frag += int(pat[1:])
-                elif pat in ("NN", "RN"):
-                    pass  # variable length — cDNA or spacer
+                elif pat in ("NN", "RN", "RN_SPACER", "RN_FLANK"):
+                    pass  # variable length — cDNA, spacer, or terminal flank
                 elif pat in ("A", "T"):
                     fixed_per_frag += 25  # estimated polyA/T average
                 else:
                     fixed_per_frag += len(pat)  # literal adapter
 
-            # Spacer cDNA flanks: (repeat + 1) spacers at avg max_spacer/2
-            spacer_overhead = (repeat + 1) * max_spacer
+            # Two terminal flanks (RN_FLANK) + (repeat - 1) interior spacers (RN_SPACER)
+            spacer_overhead = 2 * max_flank + max(0, repeat - 1) * max_spacer
             total_fixed = fixed_per_frag * repeat + spacer_overhead
             available_for_cdna = max_read_length - total_fixed
             effective_max_cdna = max(min_cDNA, available_for_cdna // repeat)
@@ -199,6 +201,8 @@ def evaluate_model_wrap(
                     max_trunc_3p,
                     min_spacer,
                     max_spacer,
+                    min_flank,
+                    max_flank,
                     fasta_path,
                     start_idx,
                 )

--- a/wrappers/evaluate_model_wrap.py
+++ b/wrappers/evaluate_model_wrap.py
@@ -41,6 +41,8 @@ def evaluate_model_wrap(
     import json
     import os
     import random
+    import resource
+    import time
 
     import numpy as np
     import polars as pl
@@ -60,6 +62,8 @@ def evaluate_model_wrap(
     from utils import get_version
 
     __version__ = get_version()
+
+    start = time.time()
 
     # ── resolve paths ──
 
@@ -334,3 +338,10 @@ def evaluate_model_wrap(
         )
 
     logger.info(f"Assessment complete. Results in {metrics_dir}/")
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/evaluate_model_wrap.py
+++ b/wrappers/evaluate_model_wrap.py
@@ -76,6 +76,8 @@ def evaluate_model_wrap(
     output_dir = os.path.abspath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
 
+    logger.info(f"Using model: {model_name} (model_dir: {model_dir})")
+
     # ── load model config ──
 
     seq_order, sequences, barcodes, UMIs, strand = seq_orders(seq_orders_file, model_name)

--- a/wrappers/featurecounts_wrap.py
+++ b/wrappers/featurecounts_wrap.py
@@ -22,9 +22,13 @@ def featurecounts_wrap(
 ):
     """Resolve container runtime, pull image if needed, then run the batched featureCounts pipeline."""
     import os
+    import resource
+    import time
 
     from scripts.container_runtime import DEFAULT_FEATURECOUNTS_IMAGE, resolve
     from scripts.featurecounts_matrix import run_featurecounts_matrix
+
+    start = time.time()
 
     bam_dir = os.path.abspath(bam_dir)
     gtf = os.path.abspath(gtf)
@@ -44,7 +48,7 @@ def featurecounts_wrap(
     logger.info("featureCounts runtime: %s", rt)
     logger.info("featureCounts invocation: %s", fc_cmd)
 
-    return run_featurecounts_matrix(
+    result = run_featurecounts_matrix(
         bam_dir=bam_dir,
         gtf=gtf,
         out_dir=out_dir,
@@ -56,3 +60,11 @@ def featurecounts_wrap(
         workers=workers,
         no_run=no_run,
     )
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")
+    return result

--- a/wrappers/generate_whitelist_wrap.py
+++ b/wrappers/generate_whitelist_wrap.py
@@ -6,6 +6,8 @@ extracted from annotation outputs, without re-running the annotation pass.
 
 import logging
 import os
+import resource
+import time
 from collections import Counter
 
 import polars as pl
@@ -196,6 +198,7 @@ def generate_whitelist_wrap(
     str
         Path to the generated discovered_whitelist.tsv.
     """
+    start = time.time()
     # Step 1: Resolve barcode columns
     if barcode_columns_str:
         logger.info(f"Using --barcode-columns override: {barcode_columns_str} (model_name '{model_name}' not used)")
@@ -230,4 +233,11 @@ def generate_whitelist_wrap(
 
     whitelist_path = os.path.join(output_dir, "annotation_metadata", "discovered_whitelist.tsv")
     logger.info(f"Whitelist generated: {whitelist_path} ({len(whitelist_df)} barcodes)")
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")
     return whitelist_path

--- a/wrappers/generate_whitelist_wrap.py
+++ b/wrappers/generate_whitelist_wrap.py
@@ -197,6 +197,10 @@ def generate_whitelist_wrap(
         Path to the generated discovered_whitelist.tsv.
     """
     # Step 1: Resolve barcode columns
+    if barcode_columns_str:
+        logger.info(f"Using --barcode-columns override: {barcode_columns_str} (model_name '{model_name}' not used)")
+    else:
+        logger.info(f"Using model: {model_name} (seq_orders: {seq_order_file or '<bundled>'})")
     barcodes, seq_order, sequences = _resolve_barcode_columns(barcode_columns_str, model_name, seq_order_file)
     logger.info(f"Barcode columns: {barcodes}")
 
@@ -217,6 +221,7 @@ def generate_whitelist_wrap(
         global_counts,
         barcodes,
         output_dir,
+        model_name,
         expected_cells=expected_cells,
         min_reads=min_reads_per_barcode,
         min_cell_ratio=min_cell_ratio,

--- a/wrappers/generate_whitelist_wrap.py
+++ b/wrappers/generate_whitelist_wrap.py
@@ -161,7 +161,7 @@ def _count_barcodes_from_files(files, barcode_columns, chunk_size):
 
 def generate_whitelist_wrap(
     output_dir,
-    model_name="10x3p_sc_ont_011",
+    model_name="10x3p_sc_ont_016",
     seq_order_file=None,
     input_file=None,
     barcode_columns_str=None,

--- a/wrappers/preprocess_wrap.py
+++ b/wrappers/preprocess_wrap.py
@@ -69,7 +69,9 @@ def preprocess_wrap(
             max_padding_fraction=max_padding_fraction,
             num_workers=threads,
         )
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/qc_metrics_wrap.py
+++ b/wrappers/qc_metrics_wrap.py
@@ -32,6 +32,7 @@ def qc_metrics_wrap(
     counts_matrix=None,
     gtf=None,
     threads=4,
+    gene_body_bed=None,
 ):
     """Generate QC metrics report from annotation outputs."""
     import os
@@ -187,8 +188,14 @@ def qc_metrics_wrap(
             else None
         )
         f_genebody = (
-            pool.submit(_plot_gene_body_coverage, bam_file, gtf_path=gtf, tsv_dir=tsv_dir, threads=threads)
-            if bam_file is not None and gtf is not None
+            pool.submit(
+                _plot_gene_body_coverage,
+                bam_file,
+                bed_path=gene_body_bed,
+                tsv_dir=tsv_dir,
+                threads=threads,
+            )
+            if bam_file is not None and gene_body_bed is not None
             else None
         )
 

--- a/wrappers/qc_metrics_wrap.py
+++ b/wrappers/qc_metrics_wrap.py
@@ -37,11 +37,14 @@ def qc_metrics_wrap(
     import os
     from concurrent.futures import ThreadPoolExecutor
 
+    import polars as pl
+
     from scripts.qc_metrics import (
         _find_file,
         _probe_schema,
         _detect_barcode_types,
         _compute_summary,
+        _set_qc_model_name,
         _plot_read_architecture,
         _plot_barcode_assignment,
         _plot_invalid_reasons,
@@ -99,6 +102,29 @@ def qc_metrics_wrap(
     # ── probe schemas (zero data loaded) ────────────────────────────────────
     vcols = _probe_schema(valid_path)
     barcode_types = _detect_barcode_types(list(vcols))
+
+    # ── resolve model name from annotation parquet ──────────────────────────
+    def _read_model_name(path):
+        if path is None:
+            return "unknown"
+        try:
+            schema = pl.scan_parquet(path).collect_schema()
+            if "model_name" not in schema.names():
+                return "unknown"
+            row = pl.scan_parquet(path).select("model_name").head(1).collect()
+            if row.height == 0:
+                return "unknown"
+            value = row.item(0, 0)
+            return str(value) if value is not None else "unknown"
+        except Exception as e:
+            logger.warning(f"Could not read model_name from {path}: {e}")
+            return "unknown"
+
+    model_name = _read_model_name(valid_path)
+    if model_name == "unknown":
+        model_name = _read_model_name(invalid_path)
+    logger.info(f"Model name resolved from annotation parquet: {model_name}")
+    _set_qc_model_name(model_name)
 
     # ── compute shared summary data ──────────────────────────────────────────
     summary = _compute_summary(valid_path, invalid_path, vcols)
@@ -328,6 +354,6 @@ def qc_metrics_wrap(
         shared_y = len(row) > 1  # side-by-side rows share y-axis
         row_figs.append(_build_row_figure(row, n_cols, shared_yaxes=shared_y))
     report_path = os.path.join(output_dir, f"{sample_name}_qc_report.html")
-    _write_html_report(report_path, row_figs, sample_name)
+    _write_html_report(report_path, row_figs, sample_name, model_name)
     logger.info(f"QC report complete -> {report_path}")
     logger.info(f"Plot data TSVs   -> {tsv_dir}")

--- a/wrappers/qc_metrics_wrap.py
+++ b/wrappers/qc_metrics_wrap.py
@@ -36,9 +36,13 @@ def qc_metrics_wrap(
 ):
     """Generate QC metrics report from annotation outputs."""
     import os
+    import time
+    import resource
     from concurrent.futures import ThreadPoolExecutor
 
     import polars as pl
+
+    start = time.time()
 
     from scripts.qc_metrics import (
         _find_file,
@@ -364,3 +368,10 @@ def qc_metrics_wrap(
     _write_html_report(report_path, row_figs, sample_name, model_name)
     logger.info(f"QC report complete -> {report_path}")
     logger.info(f"Plot data TSVs   -> {tsv_dir}")
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/read_length_distr_wrap.py
+++ b/wrappers/read_length_distr_wrap.py
@@ -17,7 +17,9 @@ def read_length_distr_wrap(output_dir):
     plot_read_len_distr(output_dir + "/full_length_pp_fa", output_dir + "/plots")
     logger.info("Finished generating the read-length distribution plot")
 
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage during alignment: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/simulate_data_wrap.py
+++ b/wrappers/simulate_data_wrap.py
@@ -28,6 +28,8 @@ def simulate_data_wrap(
     """Generate synthetic labeled training reads and save to pickle."""
     import os
     import random
+    import resource
+    import time
     import pickle
     import numpy as np
     from Bio import SeqIO
@@ -36,6 +38,7 @@ def simulate_data_wrap(
     from scripts.simulate_training_data import generate_training_reads
     from scripts.trained_models import seq_orders, get_training_structures
 
+    start = time.time()
     length_range = (min_cDNA, max_cDNA)
 
     base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,3 +99,10 @@ def simulate_data_wrap(
     with open(f"{output_dir}/simulated_data/labels.pkl", "wb") as labels_pkl:
         pickle.dump(labels, labels_pkl)
     logger.info("Outputs saved")
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/simulate_data_wrap.py
+++ b/wrappers/simulate_data_wrap.py
@@ -22,6 +22,8 @@ def simulate_data_wrap(
     max_trunc_3p=0,
     min_spacer=0,
     max_spacer=50,
+    min_flank=0,
+    max_flank=50,
 ):
     """Generate synthetic labeled training reads and save to pickle."""
     import os
@@ -81,6 +83,8 @@ def simulate_data_wrap(
         max_trunc_3p,
         min_spacer,
         max_spacer,
+        min_flank,
+        max_flank,
     )
     logger.info("Finished generating reads")
 

--- a/wrappers/split_bam_wrap.py
+++ b/wrappers/split_bam_wrap.py
@@ -19,7 +19,16 @@ def split_bam_wrap(
     prefer_csi_index: bool = False,
 ):
     """Split a BAM file into per-cell-barcode BAM files."""
+    import logging
+    import os
+    import resource
+    import time
+
     from scripts.split_bam_file import split_bam_file
+
+    logger = logging.getLogger(__name__)
+
+    start = time.time()
 
     split_bam_file(
         input_bam,
@@ -38,3 +47,10 @@ def split_bam_wrap(
         index_outputs=index_outputs,
         prefer_csi_index=prefer_csi_index,
     )
+
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/train_model_wrap.py
+++ b/wrappers/train_model_wrap.py
@@ -37,7 +37,7 @@ def load_libs():
     )
     from scripts.extract_annotated_seqs import extract_annotated_full_length_seqs
     from scripts.visualize_annot import save_plots_to_pdf
-    from scripts.available_gpus import log_gpus_used
+    from scripts.available_gpus import log_gpus_detected, log_gpus_in_use
     from utils import get_version
     import h5py
 
@@ -70,7 +70,8 @@ def load_libs():
         preprocess_sequences,
         extract_annotated_full_length_seqs,
         save_plots_to_pdf,
-        log_gpus_used,
+        log_gpus_detected,
+        log_gpus_in_use,
         get_version,
         h5py,
     )
@@ -128,13 +129,15 @@ def train_model_wrap(
         preprocess_sequences,
         extract_annotated_full_length_seqs,
         save_plots_to_pdf,
-        log_gpus_used,
+        log_gpus_detected,
+        log_gpus_in_use,
         get_version,
         h5py,
     ) = load_libs()
 
-    # Let user know whether they're running on CPU only or GPU (provided handles if so)
-    log_gpus_used()
+    # Report physical GPU detection up front; actual in-use count is logged
+    # below once the MirroredStrategy has been constructed per variant.
+    log_gpus_detected()
 
     base_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.join(base_dir, "..")
@@ -328,7 +331,7 @@ def train_model_wrap(
 
         # Multi-GPU strategy
         strategy = tf.distribute.MirroredStrategy()
-        logger.info(f"Number of devices: {strategy.num_replicas_in_sync}")
+        log_gpus_in_use(strategy=strategy)
 
         with strategy.scope():
             model = ont_read_annotator(

--- a/wrappers/train_model_wrap.py
+++ b/wrappers/train_model_wrap.py
@@ -13,6 +13,7 @@ def load_libs():
     import time
     import pickle
     import random
+    import resource
     import itertools
     from collections import Counter
 
@@ -49,6 +50,7 @@ def load_libs():
         time,
         pickle,
         random,
+        resource,
         itertools,
         Counter,
         np,
@@ -108,6 +110,7 @@ def train_model_wrap(
         time,
         pickle,
         random,
+        resource,
         itertools,
         Counter,
         np,
@@ -134,6 +137,8 @@ def train_model_wrap(
         get_version,
         h5py,
     ) = load_libs()
+
+    start = time.time()
 
     # Report physical GPU detection up front; actual in-use count is logged
     # below once the MirroredStrategy has been constructed per variant.
@@ -415,3 +420,11 @@ def train_model_wrap(
             chars_per_line=150,
         )
         gc.collect()
+
+    logger.info("Note: peak memory does not include GPU device memory.")
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
+    logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
+    logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")

--- a/wrappers/visualize_wrap.py
+++ b/wrappers/visualize_wrap.py
@@ -103,6 +103,8 @@ def visualize_wrap(
     if not os.path.isdir(models_dir):
         raise FileNotFoundError(f"Model directory not found: {models_dir}")
 
+    logger.info(f"Using model: {model_name} (models_dir: {models_dir})")
+
     utils_dir = os.path.join(base_dir, "utils")
     utils_dir = os.path.abspath(utils_dir)
 

--- a/wrappers/visualize_wrap.py
+++ b/wrappers/visualize_wrap.py
@@ -245,8 +245,10 @@ def visualize_wrap(
     save_plots_to_pdf(selected_reads, annotated_reads, selected_read_names, pdf_filename, colors, chars_per_line=150)
     logger.info(f"Visualization saved to {pdf_filename}\n")
 
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    max_rss_mb = usage.ru_maxrss / 1024 if os.uname().sysname == "Linux" else usage.ru_maxrss  # Linux gives KB
+    usage_self = resource.getrusage(resource.RUSAGE_SELF)
+    usage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss_kb = usage_self.ru_maxrss + usage_children.ru_maxrss
+    max_rss_mb = max_rss_kb / 1024 if os.uname().sysname == "Linux" else max_rss_kb
     logger.info(f"Peak memory usage: {max_rss_mb:.2f} MB")
     logger.info(f"Elapsed time: {time.time() - start:.2f} seconds")
 

--- a/wrappers/visualize_wrap.py
+++ b/wrappers/visualize_wrap.py
@@ -25,7 +25,7 @@ def load_libs():
     from scripts.trained_models import trained_models, seq_orders, get_valid_structures
     from scripts.annotate_new_data import annotate_new_data_parallel
     from scripts.visualize_annot import save_plots_to_pdf
-    from scripts.available_gpus import log_gpus_used
+    from scripts.available_gpus import log_gpus_detected, log_gpus_in_use
 
     return (
         os,
@@ -43,7 +43,8 @@ def load_libs():
         seq_orders,
         annotate_new_data_parallel,
         save_plots_to_pdf,
-        log_gpus_used,
+        log_gpus_detected,
+        log_gpus_in_use,
         get_valid_structures,
     )
 
@@ -81,7 +82,8 @@ def visualize_wrap(
         seq_orders,
         annotate_new_data_parallel,
         save_plots_to_pdf,
-        log_gpus_used,
+        log_gpus_detected,
+        log_gpus_in_use,
         get_valid_structures,
     ) = load_libs()
 
@@ -92,8 +94,9 @@ def visualize_wrap(
 
     start = time.time()
 
-    # Let user know whether they're running on CPU only or GPU (provided handles if so)
-    log_gpus_used()
+    # Report physical GPU detection up front; actual in-use count is logged
+    # below once the (single-device) build_model call has succeeded.
+    log_gpus_detected()
 
     base_dir = os.path.dirname(os.path.abspath(__file__))
     base_dir = os.path.abspath(os.path.join(base_dir, ".."))
@@ -131,6 +134,9 @@ def visualize_wrap(
     except Exception as e:
         logger.error(f"Error encountered while building model: {e}")
         sys.exit(1)
+
+    # visualize always runs single-device by design (strategy=None).
+    log_gpus_in_use(strategy=None)
 
     palette = ["red", "blue", "green", "purple", "pink", "cyan", "magenta", "orange", "brown"]
     colors = {"random_s": "black", "random_e": "black", "cDNA": "gray", "polyT": "orange", "polyA": "orange"}


### PR DESCRIPTION
* Default annotation model switched from 10x3p_sc_ont_013 (Conv+CRF) to 10x3p_sc_ont_016 (CNN-BiLSTM-CRF, 3 conv × 64 filters, 1 BiLSTM × 32 units). Empirically validated to ~525 kb on 4× L40S.
* GPU stability hardening — bounded join→SIGTERM→SIGKILL worker shutdown to prevent NCCL ring corruption across jobs, predict_with_backoff now raises on stale model after K.clear_session(), XLA disabled (tf2crf Viterbi incompatibility on TF 2.15), CUDA_VISIBLE_DEVICES no longer blanked when no GPUs found, model state persisted across length bins.
* QC enhancements — new --gene-body-bed flag accepting RSeQC-style BED12 (replaces auto-extraction from GTF); single-pass BAM scan is significantly faster.
* Training/simulation — new --min-flank/--max-flank for terminal cDNA flanks, separate from interior --min/max-spacer; pre-flight read-length math corrected in assess-model.
* Observability — every pipeline stage reports peak memory + elapsed time; logs and artifacts include the model name.
* Bug fixes — barcode-correct falls back to bundled seq_orders.yaml when only --model-name is given; extract_annotated_seqs no longer crashes on empty Starts.
* Documentation — resource_requirements.qmd re-anchored on _016 (bpt 6,644 → 2,916, k 73.4 → 32.2 KB/bp); new --max-batch-size per-VRAM-tier tuning guidance; XLA references removed; tentative-figures disclaimer added pending per-GPU benchmarking.